### PR TITLE
feat: idb blockstore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@vascosantos/ipfs-unixfs-importer": "^9.0.0",
         "@web-std/blob": "^2.1.1",
         "bl": "^5.0.0",
+        "idb-keyval": "^5.0.6",
         "ipfs-core-types": "^0.5.0",
         "ipfs-core-utils": "^0.8.0",
         "ipfs-utils": "^8.0.0",
@@ -6243,6 +6244,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.6.tgz",
+      "integrity": "sha512-6lJuVbwyo82mKSH6Wq2eHkt9LcbwHAelMIcMe0tP4p20Pod7tTxq9zf0ge2n/YDfMOpDryerfmmYyuQiaFaKOg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -18291,6 +18297,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
+    },
+    "idb-keyval": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.6.tgz",
+      "integrity": "sha512-6lJuVbwyo82mKSH6Wq2eHkt9LcbwHAelMIcMe0tP4p20Pod7tTxq9zf0ge2n/YDfMOpDryerfmmYyuQiaFaKOg=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "license": "MIT",
       "dependencies": {
         "@ipld/car": "^3.0.3",
-        "@vascosantos/ipfs-unixfs-exporter": "^7.0.0",
-        "@vascosantos/ipfs-unixfs-importer": "^9.0.0",
+        "@vascosantos/ipfs-unixfs-exporter": "^8.0.0",
+        "@vascosantos/ipfs-unixfs-importer": "^10.0.0",
         "@web-std/blob": "^2.1.1",
         "bl": "^5.0.0",
         "idb-keyval": "^5.0.6",
@@ -3293,9 +3293,10 @@
       "dev": true
     },
     "node_modules/@vascosantos/ipfs-unixfs-exporter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.0.tgz",
-      "integrity": "sha512-2lt5wbmVq5wPiY89mGyVQ+z7HuEH4V6hbrwe/dCZOMZdZ1tat6uFvelHd6llHMxvlKalmcU2/QtUPjSDKX+/KQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-8.0.0.tgz",
+      "integrity": "sha512-NaPI4ybu8EqsDw3EiLLJfVtxw3uXLWeyfmS/CGRfwl82Ue6lVm2L0Ebquf1h3K1YdXhfNiaL4TKKa/ZrCX+1eA==",
+      "license": "MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.0",
         "@ipld/dag-pb": "^2.0.2",
@@ -3313,9 +3314,9 @@
       }
     },
     "node_modules/@vascosantos/ipfs-unixfs-importer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.3.tgz",
-      "integrity": "sha512-kVcp+yZavn5Tn5EL7RHH51kSoO+gx1Yz22NtzmPFVNRx/cZ039VNZFI5XHkFT4FkFiskLv97nEzM/rOyug0wRw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-10.0.0.tgz",
+      "integrity": "sha512-rtvX3GkdWp74tmT8anPiYQgM3GtqmEQPHn+9IdZTl7KcjpjlmpwwBvM21Vqv0Oby2CjYAtQqSq9Az0dmABRqSA==",
       "dependencies": {
         "@ipld/dag-pb": "^2.1.1",
         "bl": "^5.0.0",
@@ -15989,9 +15990,9 @@
       "dev": true
     },
     "@vascosantos/ipfs-unixfs-exporter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.0.tgz",
-      "integrity": "sha512-2lt5wbmVq5wPiY89mGyVQ+z7HuEH4V6hbrwe/dCZOMZdZ1tat6uFvelHd6llHMxvlKalmcU2/QtUPjSDKX+/KQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-8.0.0.tgz",
+      "integrity": "sha512-NaPI4ybu8EqsDw3EiLLJfVtxw3uXLWeyfmS/CGRfwl82Ue6lVm2L0Ebquf1h3K1YdXhfNiaL4TKKa/ZrCX+1eA==",
       "requires": {
         "@ipld/dag-cbor": "^6.0.0",
         "@ipld/dag-pb": "^2.0.2",
@@ -16005,9 +16006,9 @@
       }
     },
     "@vascosantos/ipfs-unixfs-importer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.3.tgz",
-      "integrity": "sha512-kVcp+yZavn5Tn5EL7RHH51kSoO+gx1Yz22NtzmPFVNRx/cZ039VNZFI5XHkFT4FkFiskLv97nEzM/rOyug0wRw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-10.0.0.tgz",
+      "integrity": "sha512-rtvX3GkdWp74tmT8anPiYQgM3GtqmEQPHn+9IdZTl7KcjpjlmpwwBvM21Vqv0Oby2CjYAtQqSq9Az0dmABRqSA==",
       "requires": {
         "@ipld/dag-pb": "^2.1.1",
         "bl": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@vascosantos/ipfs-unixfs-importer": "^9.0.0",
     "@web-std/blob": "^2.1.1",
     "bl": "^5.0.0",
+    "idb-keyval": "^5.0.6",
     "ipfs-core-types": "^0.5.0",
     "ipfs-core-utils": "^0.8.0",
     "ipfs-utils": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "compile:esm": "ttsc -p tsconfig.json && echo '{ \"type\" : \"module\" }' > dist/esm/package.json",
     "compile:cjs": "tsc -p tsconfig-cjs.json",
     "lint": "tslint 'src/**/*.ts?(x)'",
-    "test": "npm run test:node && npm run test:browser",
-    "test:node": "npm run build && mocha -r ts-node/register test/**/*.node.test.ts",
-    "test:browser": "npm run build && playwright-test test/**/*.browser.test.ts"
+    "test": "npm run lint && npm run build && npm run test:node && npm run test:browser",
+    "test:node": "mocha -r ts-node/register test/**/*.node.test.ts",
+    "test:browser": "playwright-test test/**/*.browser.test.ts"
   },
   "exports": {
     "./pack": {

--- a/package.json
+++ b/package.json
@@ -117,8 +117,8 @@
   "homepage": "https://github.com/vasco-santos/ipfs-car#readme",
   "dependencies": {
     "@ipld/car": "^3.0.3",
-    "@vascosantos/ipfs-unixfs-exporter": "^7.0.0",
-    "@vascosantos/ipfs-unixfs-importer": "^9.0.0",
+    "@vascosantos/ipfs-unixfs-exporter": "^8.0.0",
+    "@vascosantos/ipfs-unixfs-importer": "^10.0.0",
     "@web-std/blob": "^2.1.1",
     "bl": "^5.0.0",
     "idb-keyval": "^5.0.6",

--- a/src/blockstore/idb.ts
+++ b/src/blockstore/idb.ts
@@ -15,12 +15,12 @@ export class IdbBlockStore implements Blockstore {
   private store: idb.UseStore
 
   constructor () {
-    const dbName = `${Date.now()}-${Math.random()}`
+    const dbName = `IdbBlockStore-${Date.now()}-${Math.random()}`
     this.store = idb.createStore(dbName, `IdbBlockStore`)
   }
 
   async * blocks () {
-    const keys = await idb.keys()
+    const keys = await idb.keys(this.store)
     for (const key of keys) {
       yield idb.get(key, this.store)
     }

--- a/src/blockstore/idb.ts
+++ b/src/blockstore/idb.ts
@@ -1,0 +1,41 @@
+import * as idb from 'idb-keyval'
+
+import { CID } from 'multiformats'
+import { Block } from '@ipld/car/api'
+
+import { Blockstore } from './index'
+
+/**
+ * Save blocks to IndexedDB in the browser via idb-keyval
+ * Creates a probably unique indexed db per instance to ensure that the 
+ * blocks iteration method only returns blocks from this invocation, 
+ * and so that the caller can destory it without affecting others.
+ */
+export class IdbBlockStore implements Blockstore {
+  private store: idb.UseStore
+
+  constructor () {
+    const dbName = `${Date.now()}-${Math.random()}`
+    this.store = idb.createStore(dbName, `IdbBlockStore`)
+  }
+
+  async * blocks () {
+    const keys = await idb.keys()
+    for (const key of keys) {
+      yield idb.get(key, this.store)
+    }
+  }
+
+  async put (block: Block) {
+    await idb.set(block.cid.toString(), block, this.store)
+    return block
+  }
+
+  async get (cid: CID): Promise<Block | undefined> {
+    return idb.get(cid.toString(), this.store)
+  }
+
+  async destroy () {
+    return idb.clear(this.store)
+  }
+}

--- a/src/blockstore/idb.ts
+++ b/src/blockstore/idb.ts
@@ -7,8 +7,8 @@ import { Blockstore } from './index'
 
 /**
  * Save blocks to IndexedDB in the browser via idb-keyval
- * Creates a probably unique indexed db per instance to ensure that the 
- * blocks iteration method only returns blocks from this invocation, 
+ * Creates a probably unique indexed db per instance to ensure that the
+ * blocks iteration method only returns blocks from this invocation,
  * and so that the caller can destory it without affecting others.
  */
 export class IdbBlockStore implements Blockstore {

--- a/src/blockstore/index.ts
+++ b/src/blockstore/index.ts
@@ -3,7 +3,7 @@ import { CID } from 'multiformats'
 
 export interface Blockstore {
   put(block: Block): Promise<Block>
-  get(cid: CID): Promise<Block>
+  get(cid: CID): Promise<Block | undefined>
   blocks(): AsyncGenerator<Block, void, unknown>
   destroy(): Promise<void>
 }

--- a/test/blockstore/index.browser.test.ts
+++ b/test/blockstore/index.browser.test.ts
@@ -9,7 +9,7 @@ import { MemoryBlockStore } from '../../src/blockstore/memory'
 import { IdbBlockStore } from '../../src/blockstore/idb'
 
 describe('blockstore', () => {
-  [MemoryBlockStore, IdbBlockStore].map((Blockstore) => {
+  [IdbBlockStore, MemoryBlockStore].map((Blockstore) => {
     describe(`with ${Blockstore.name}`, () => {
       let blockstore: BlockstoreInterface
       const cid = CID.parse('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
@@ -24,7 +24,9 @@ describe('blockstore', () => {
       it('can put and get', async () => {
         await blockstore.put({ cid, bytes })
         const storedBlock = await blockstore.get(cid)
-
+        if (!storedBlock) {
+          expect.fail("should return a block");
+        }
         expect(cid.equals(storedBlock.cid)).eql(true)
         expect(equals(bytes, storedBlock.bytes)).eql(true)
       })

--- a/test/blockstore/index.browser.test.ts
+++ b/test/blockstore/index.browser.test.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai'
+
+import { CID } from 'multiformats'
+import equals from 'uint8arrays/equals'
+import all from 'it-all'
+
+import { Blockstore as BlockstoreInterface } from '../../src/blockstore'
+import { MemoryBlockStore } from '../../src/blockstore/memory'
+import { IdbBlockStore } from '../../src/blockstore/idb'
+
+describe('blockstore', () => {
+  [MemoryBlockStore, IdbBlockStore].map((Blockstore) => {
+    describe(`with ${Blockstore.name}`, () => {
+      let blockstore: BlockstoreInterface
+      const cid = CID.parse('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
+      const bytes = new Uint8Array([21, 31])
+
+      beforeEach(() => {
+        blockstore = new Blockstore()
+      })
+
+      afterEach(() => blockstore.destroy())
+
+      it('can put and get', async () => {
+        await blockstore.put({ cid, bytes })
+        const storedBlock = await blockstore.get(cid)
+
+        expect(cid.equals(storedBlock.cid)).eql(true)
+        expect(equals(bytes, storedBlock.bytes)).eql(true)
+      })
+
+      it('can iterate on stored blocks', async () => {
+        await blockstore.put({ cid, bytes })
+        const blocks = await all(blockstore.blocks())
+
+        expect(blocks.length).eql(1)
+        expect(cid.equals(blocks[0].cid)).eql(true)
+        expect(equals(bytes, blocks[0].bytes)).eql(true)
+      })
+
+      it('can put several blocks in parallel', async () => {
+        const cid2 = CID.parse('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby5y')
+        const cid3 = CID.parse('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby6y')
+
+        await Promise.all([
+          blockstore.put({ cid, bytes }),
+          blockstore.put({ cid: cid2, bytes }),
+          blockstore.put({ cid: cid3, bytes })
+        ])
+
+        const blocks = await all(blockstore.blocks())
+        expect(blocks.length).eql(3)
+      })
+    })
+  })
+})

--- a/test/blockstore/index.node.test.ts
+++ b/test/blockstore/index.node.test.ts
@@ -24,7 +24,9 @@ describe('blockstore', () => {
       it('can put and get', async () => {
         await blockstore.put({ cid, bytes })
         const storedBlock = await blockstore.get(cid)
-
+        if (!storedBlock) {
+          expect.fail("should return a block");
+        }
         expect(cid.equals(storedBlock.cid)).eql(true)
         expect(equals(bytes, storedBlock.bytes)).eql(true)
       })


### PR DESCRIPTION
- add IdbBlockStore impl on top of idb-keyval
- add browser only test for IdbBlockStore and MemoryBlockStore
- updates BlockStore interface so that get(cid) can return undefined if the the block is not in the store


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>