### PR TITLE
feat: add unpackStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ ipfs-car --list-cids path/to/my.car
 ## API
 
 To pack files into content-addressable archives, you can use the functions provided in:
+
 - `ipfs-car/pack` for consuming a [CAR writer](https://github.com/ipld/js-car#carwriter) async iterable
 - `ipfs-car/pack/blob` for getting a blob with the CAR file
 - `ipfs-car/pack/fs` for storing in the local file system (**Node.js only**)
@@ -170,6 +171,22 @@ const carReader = await CarReader.fromIterable(inStream)
 
 const files = []
 for await (const file of unpack(carReader)) {
+  // Iterate over files
+}
+```
+
+### `ipfs-car/unpackStream`
+
+Takes an AsyncIterable and yields files to be consumed.
+
+```js
+import fs from 'fs'
+import { unpackStream } from 'ipfs-car/unpack'
+
+const inStream = fs.createReadStream(`${process.cwd()}/output.car`)
+
+const files = []
+for await (const file of unpackStream(inStream)) {
   // Iterate over files
 }
 ```

--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
       "import": "./dist/esm/blockstore/fs.js",
       "require": "./dist/cjs/blockstore/fs.js"
     },
+    "./blockstore/idb": {
+      "browser": "./dist/esm/blockstore/idb.js",
+      "import": null,
+      "require": null
+    },
     "./blockstore/memory": {
       "browser": "./dist/esm/blockstore/memory.js",
       "import": "./dist/esm/blockstore/memory.js",
@@ -105,6 +110,9 @@
       ],
       "blockstore/fs": [
         "dist/types/blockstore/fs.d.ts"
+      ],
+      "blockstore/idb": [
+        "dist/types/blockstore/idb.d.ts"
       ],
       "blockstore/memory": [
         "dist/types/blockstore/memory.d.ts"

--- a/src/blockstore/README.md
+++ b/src/blockstore/README.md
@@ -8,6 +8,7 @@ The Blockstore implementations follows the [Blockstore Interface](./index.d.ts).
 
 - [FsBlockStore](./fs.ts) with a local file system backend (Node.js environments)
 - [MemoryBlockStore](./memory.ts) with an in-memory backend
+- [IdbBlockStore](./idb.ts) for browsers with IndexedDb via `idb-keyval`
 - [LevelBlockStore](https://github.com/vasco-santos/level-blockstore) with a [level](https://www.npmjs.com/package/level) backend (Node.js, Electron and browser environments)
 
 ## Usage
@@ -16,6 +17,12 @@ The Blockstore implementations follows the [Blockstore Interface](./index.d.ts).
 
 ```js
 import { FsBlockStore } from 'ipfs-car/blockstore/fs'
+```
+
+- IdbBlockStore
+
+```js
+import { IdbBlockStore } from 'ipfs-car/blockstore/idb'
 ```
 
 - MemoryBlockStore

--- a/src/unpack/fs.ts
+++ b/src/unpack/fs.ts
@@ -12,7 +12,7 @@ import { FsBlockStore } from '../blockstore/fs'
 const toIterable = require('stream-to-it')
 
 import { unpack, unpackStream } from './index'
-import { Blockstore } from '../blockstore'
+import { Blockstore } from '../blockstore/index'
 
 // Node only, read a car from fs, write files to fs
 export async function unpackToFs ({input, roots, output}: {input: string, roots?: CID[], output?: string}) {

--- a/src/unpack/index.ts
+++ b/src/unpack/index.ts
@@ -42,7 +42,7 @@ export async function* unpack(carReader: CarReader, roots?: CID[]): AsyncIterabl
 export async function* unpackStream(readable: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>, { roots, blockstore: userBlockstore }: { roots?: CID[], blockstore?: Blockstore } = {}): AsyncIterable<UnixFSEntry> {
   const carIterator = await CarBlockIterator.fromIterable(asAsyncIterable(readable))
   const blockstore = userBlockstore || new MemoryBlockStore()
-  
+
   for await (const block of carIterator) {
     await blockstore.put(block)
   }

--- a/src/unpack/index.ts
+++ b/src/unpack/index.ts
@@ -1,12 +1,16 @@
 import { equals } from 'uint8arrays'
 import { sha256 } from 'multiformats/hashes/sha2'
-
+import toIterable from 'browser-readablestream-to-it'
+import { CarBlockIterator } from '@ipld/car/iterator'
 import { CarReader } from '@ipld/car/api'
 import { Block } from '@ipld/car/api'
 import { CID } from 'multiformats'
 import exporter from '@vascosantos/ipfs-unixfs-exporter'
 import type { UnixFSEntry } from '@vascosantos/ipfs-unixfs-exporter'
 export type { UnixFSEntry }
+
+import { Blockstore } from '../blockstore/index'
+import { MemoryBlockStore } from '../blockstore/memory'
 
 // Export unixfs entries from car file
 export async function* unpack(carReader: CarReader, roots?: CID[]): AsyncIterable<UnixFSEntry> {
@@ -35,7 +39,51 @@ export async function* unpack(carReader: CarReader, roots?: CID[]): AsyncIterabl
   }
 }
 
+export async function* unpackStream(readable: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>, { roots, blockstore: userBlockstore }: { roots?: CID[], blockstore?: Blockstore } = {}): AsyncIterable<UnixFSEntry> {
+  const carIterator = await CarBlockIterator.fromIterable(asAsyncIterable(readable))
+  const blockstore = userBlockstore || new MemoryBlockStore()
+  
+  for await (const block of carIterator) {
+    await blockstore.put(block)
+  }
+
+  const verifyingBlockStore = {
+    get: async (cid: CID) => {
+      const res = await blockstore.get(cid)
+      if (!res) {
+        throw new Error(`Incomplete CAR. Block missing for CID ${cid}`)
+      }
+      if (!isValid(res)) {
+        throw new Error(`Invalid CAR. Hash of block data does not match CID ${cid}`)
+      }
+      return res
+    },
+    put: ({ cid, bytes }: { cid: CID, bytes: Uint8Array }) => {
+      return Promise.reject(new Error('should not put blocks'))
+    }
+  }
+
+  if (!roots || roots.length === 0 ) {
+    roots = await carIterator.getRoots()
+  }
+
+  for (const root of roots) {
+    yield* exporter.recursive(root, verifyingBlockStore)
+  }
+}
+
 async function isValid ({ cid, bytes }: Block) {
   const hash = await sha256.digest(bytes)
   return equals(hash.digest, cid.multihash.digest)
+}
+
+/**
+ * Upgrade a ReadableStream to an AsyncIterable if it isn't already
+ *
+ * ReadableStream (e.g res.body) is asyncIterable in node, but not in chrome, yet.
+ * see: https://bugs.chromium.org/p/chromium/issues/detail?id=929585
+ */
+ function asAsyncIterable(readable: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>): AsyncIterable<Uint8Array> {
+  // @ts-ignore how to convince tsc that we are checking the type here?
+   return Symbol.asyncIterator in readable ? readable : toIterable(readable)
 }

--- a/test/unpack/index.browser.test.ts
+++ b/test/unpack/index.browser.test.ts
@@ -4,27 +4,41 @@ import all from 'it-all'
 import { CarReader } from '@ipld/car'
 
 import { pack } from '../../src/pack'
-import { unpack } from '../../src/unpack'
+import { unpack, unpackStream } from '../../src/unpack'
 
 import { MemoryBlockStore } from '../../src/blockstore/memory'
+import { IdbBlockStore } from '../../src/blockstore/idb'
 
 describe('unpack', () => {
-  [MemoryBlockStore].map((Blockstore) => {
+  it('with iterable input', async () => {
+    const { out } = await pack({
+      input: [new Uint8Array([21, 31])],
+      blockstore: new MemoryBlockStore()
+    })
+
+    let bytes = new Uint8Array([])
+    for await (const part of out) {
+      bytes = concat([bytes, new Uint8Array(part)])
+    }
+
+    const carReader = await CarReader.fromBytes(bytes)
+    const files = await all(unpack(carReader))
+
+    expect(files.length).to.eql(1)
+    expect(files[0].type).to.eql('raw')
+    expect(files[0].name).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
+  })
+})
+
+describe('unpackStream', () => {
+  [IdbBlockStore, MemoryBlockStore].map((Blockstore) => {
     describe(`with ${Blockstore.name}`, () => {
       it('with iterable input', async () => {
         const { out } = await pack({
           input: [new Uint8Array([21, 31])],
-          blockstore: new Blockstore()
+          blockstore: new MemoryBlockStore()
         })
-
-        let bytes = new Uint8Array([])
-        for await (const part of out) {
-          bytes = concat([bytes, new Uint8Array(part)])
-        }
-
-        const carReader = await CarReader.fromBytes(bytes)
-        const files = await all(unpack(carReader))
-
+        const files = await all(unpackStream(out, {blockstore: new Blockstore()}))
         expect(files.length).to.eql(1)
         expect(files[0].type).to.eql('raw')
         expect(files[0].name).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')

--- a/test/unpack/index.browser.test.ts
+++ b/test/unpack/index.browser.test.ts
@@ -10,7 +10,7 @@ import { MemoryBlockStore } from '../../src/blockstore/memory'
 import { IdbBlockStore } from '../../src/blockstore/idb'
 
 describe('unpack', () => {
-  it('with iterable input', async () => {
+  it('with CarReader input', async () => {
     const { out } = await pack({
       input: [new Uint8Array([21, 31])],
       blockstore: new MemoryBlockStore()

--- a/test/unpack/index.browser.test.ts
+++ b/test/unpack/index.browser.test.ts
@@ -43,6 +43,24 @@ describe('unpackStream', () => {
         expect(files[0].type).to.eql('raw')
         expect(files[0].name).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
       })
+      it('with readablestream input', async () => {
+        const { out } = await pack({
+          input: [new Uint8Array([21, 31])],
+          blockstore: new MemoryBlockStore()
+        })
+        const stream = new ReadableStream({
+          async pull(controller) {
+            for await (const chunk of out) {
+              controller.enqueue(chunk)
+            }
+            controller.close()
+          }
+        })
+        const files = await all(unpackStream(stream, {blockstore: new Blockstore()}))
+        expect(files.length).to.eql(1)
+        expect(files[0].type).to.eql('raw')
+        expect(files[0].name).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
+      })
     })
   })
 })

--- a/test/unpack/index.node.test.ts
+++ b/test/unpack/index.node.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai'
 import { CID } from 'multiformats'
 import { CarReader } from '@ipld/car'
 
-import { unpack } from '../../src/unpack'
+import { unpack, unpackStream } from '../../src/unpack'
 import { unpackToFs, unpackStreamToFs } from '../../src/unpack/fs'
 
 const rawCidString = 'bafkreigk2mcysiwgmacvilb3q6lcdaq53zlwu3jn4pj6qev2lylyfbqfdm'
@@ -23,6 +23,20 @@ describe('unpack', () => {
       files.push(file)
     }
 
+    expect(files).to.have.lengthOf(1)
+  })
+})
+
+describe('unpackStream', () => {
+  it('file system stream', async () => {
+    const inStream = fs.createReadStream(`${__dirname}/../fixtures/raw.car`)
+    const files = []
+
+    for await (const file of unpackStream(inStream)) {
+      expect(file.path).to.eql(rawCidString)
+      expect(rawCid.equals(file.cid)).to.eql(true)
+      files.push(file)
+    }
     expect(files).to.have.lengthOf(1)
   })
 })

--- a/test/unpack/index.node.test.ts
+++ b/test/unpack/index.node.test.ts
@@ -6,6 +6,9 @@ import { CarReader } from '@ipld/car'
 import { unpack, unpackStream } from '../../src/unpack'
 import { unpackToFs, unpackStreamToFs } from '../../src/unpack/fs'
 
+import { MemoryBlockStore } from '../../src/blockstore/memory'
+import { FsBlockStore } from '../../src/blockstore/fs'
+
 const rawCidString = 'bafkreigk2mcysiwgmacvilb3q6lcdaq53zlwu3jn4pj6qev2lylyfbqfdm'
 const rawCid = CID.parse(rawCidString)
 
@@ -28,16 +31,18 @@ describe('unpack', () => {
 })
 
 describe('unpackStream', () => {
-  it('file system stream', async () => {
-    const inStream = fs.createReadStream(`${__dirname}/../fixtures/raw.car`)
-    const files = []
+  [FsBlockStore, MemoryBlockStore].map((Blockstore) => {
+    it('file system stream', async () => {
+      const inStream = fs.createReadStream(`${__dirname}/../fixtures/raw.car`)
+      const files = []
 
-    for await (const file of unpackStream(inStream)) {
-      expect(file.path).to.eql(rawCidString)
-      expect(rawCid.equals(file.cid)).to.eql(true)
-      files.push(file)
-    }
-    expect(files).to.have.lengthOf(1)
+      for await (const file of unpackStream(inStream, {blockstore: new Blockstore()})) {
+        expect(file.path).to.eql(rawCidString)
+        expect(rawCid.equals(file.cid)).to.eql(true)
+        files.push(file)
+      }
+      expect(files).to.have.lengthOf(1)
+    })
   })
 })
 


### PR DESCRIPTION
Takes an AsyncIterable and yields UnixFSEntries.

```js
import fs from 'fs'
import { unpackStream } from 'ipfs-car/unpack'

const inStream = fs.createReadStream(`${process.cwd()}/output.car`)

const files = []
for await (const file of unpackStream(inStream)) {
  // Iterate over files
}
```

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>