### PR TITLE
fix: fs blockstore destroy without open

### DIFF
--- a/src/blockstore/fs.ts
+++ b/src/blockstore/fs.ts
@@ -66,6 +66,9 @@ export class FsBlockStore implements Blockstore {
   }
 
   async destroy () {
-    await fs.promises.rm(this.path, { recursive: true })
+    if (this._opened) {
+      await fs.promises.rm(this.path, { recursive: true })
+    }
+    this._opened = false
   }
 }

--- a/test/blockstore/index.node.test.ts
+++ b/test/blockstore/index.node.test.ts
@@ -53,6 +53,10 @@ describe('blockstore', () => {
         const blocks = await all(blockstore.blocks())
         expect(blocks.length).eql(3)
       })
+
+      it('can destroy immediately after creating', () => {
+        // Do nothing, rely on beforeEach and afterEach
+      })
     })
   })
 })


### PR DESCRIPTION
When destroying fsblockstore before it is open (tmp folder created), it errors to remove a not existent folder.