### PR TITLE
fix: memory blockstore types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.4.2",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@ipld/car": "^3.0.3",
+        "@ipld/car": "^3.1.4",
         "@vascosantos/ipfs-unixfs-exporter": "^8.0.0",
         "@vascosantos/ipfs-unixfs-importer": "^10.0.0",
         "@web-std/blob": "^2.1.1",
@@ -22,7 +22,7 @@
         "it-pipe": "^1.1.0",
         "meow": "^9.0.0",
         "move-file": "^2.0.0",
-        "multiformats": "^9.0.4",
+        "multiformats": "^9.1.2",
         "stream-to-it": "^0.2.3",
         "streaming-iterables": "^5.0.4",
         "uint8arrays": "^2.1.5"
@@ -2073,9 +2073,9 @@
       }
     },
     "node_modules/@ipld/car": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.3.tgz",
-      "integrity": "sha512-/7NMX+FJqAQwv66ZzIWiE/6AnnR2IH+RHehXcotk+0HbOi/YFMihN6e9dfWwRSqQ2B8HhahRSaPAcf+eUTRn6Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.4.tgz",
+      "integrity": "sha512-iXgV50nJD2k7/sLNQig6KeIbuRtWhqp8NTKOVxCYwPe723MkCsf/7ACeiSWC01N4kZfd95M2eROuIEQfWA/4cg==",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.0",
         "@types/varint": "^6.0.0",
@@ -2093,9 +2093,9 @@
       }
     },
     "node_modules/@ipld/dag-pb": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.2.tgz",
-      "integrity": "sha512-N9Si83HlDViXFL/xLOyC4CnD1DOQl7NaSkHKdCK4jJRoAzl/Hw0Md0GBB3wNWUWUxdvxQlgyBSgo96ROp9lypg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.3.tgz",
+      "integrity": "sha512-5Rb+1y1Ov1rMeqmLjyXdbdFEO2ja3IphDfleHJOO79fDbR8GThSFnvwZoOG0wSW1X9IwHeUDErht8vt8i+a72A==",
       "dependencies": {
         "multiformats": "^9.0.0"
       }
@@ -3225,9 +3225,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
-      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
+      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3262,24 +3262,24 @@
       }
     },
     "node_modules/@types/yargs": {
-      "version": "15.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-      "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+      "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/yargs-parser": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "peer": true
     },
     "node_modules/@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -4154,9 +4154,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001241",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
-      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
+      "version": "1.0.30001242",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
+      "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -4735,9 +4735,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
-      "integrity": "sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==",
       "peer": true
     },
     "node_modules/debug": {
@@ -5020,9 +5020,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.765",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.765.tgz",
-      "integrity": "sha512-4NhcsfZYlr1x4FehYkK+R9CNNTOZ8vLcIu8Y1uWehxYp5r/jlCGAfBqChIubEfdtX+rBQpXx4yJuX/dzILH/nw=="
+      "version": "1.3.768",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.768.tgz",
+      "integrity": "sha512-I4UMZHhVSK2pwt8jOIxTi3GIuc41NkddtKT/hpuxp9GO5UWJgDKTBa4TACppbVAuKtKbMK6BhQZvT5tFF1bcNA=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5621,9 +5621,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -8975,9 +8975,9 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
-      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.2.tgz",
+      "integrity": "sha512-ca/Mvp8iQmCyLomEpMHRr0MgyBN3nTZ9YznOsoCBajyI51Y9TL8UNsX1CQXW/RGsYcto+OHmGelFZzsmdl66wA=="
     },
     "node_modules/multihashes": {
       "version": "4.0.2",
@@ -12082,9 +12082,9 @@
       }
     },
     "node_modules/stream-to-it": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.3.tgz",
-      "integrity": "sha512-xaK9EjPtLox5rrC7YLSBXSanTtUJN/lzJlMFvy9VaROmnyvy0U/X6m2uMhXPJRn3g3M9uOSIzTszW7BPiWSg9w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "dependencies": {
         "get-iterator": "^1.0.2"
       }
@@ -13320,9 +13320,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
-      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
+      "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -14938,9 +14938,9 @@
       }
     },
     "@ipld/car": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.3.tgz",
-      "integrity": "sha512-/7NMX+FJqAQwv66ZzIWiE/6AnnR2IH+RHehXcotk+0HbOi/YFMihN6e9dfWwRSqQ2B8HhahRSaPAcf+eUTRn6Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.4.tgz",
+      "integrity": "sha512-iXgV50nJD2k7/sLNQig6KeIbuRtWhqp8NTKOVxCYwPe723MkCsf/7ACeiSWC01N4kZfd95M2eROuIEQfWA/4cg==",
       "requires": {
         "@ipld/dag-cbor": "^6.0.0",
         "@types/varint": "^6.0.0",
@@ -14958,9 +14958,9 @@
       }
     },
     "@ipld/dag-pb": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.2.tgz",
-      "integrity": "sha512-N9Si83HlDViXFL/xLOyC4CnD1DOQl7NaSkHKdCK4jJRoAzl/Hw0Md0GBB3wNWUWUxdvxQlgyBSgo96ROp9lypg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.3.tgz",
+      "integrity": "sha512-5Rb+1y1Ov1rMeqmLjyXdbdFEO2ja3IphDfleHJOO79fDbR8GThSFnvwZoOG0wSW1X9IwHeUDErht8vt8i+a72A==",
       "requires": {
         "multiformats": "^9.0.0"
       }
@@ -15921,9 +15921,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
-      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
+      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -15958,24 +15958,24 @@
       }
     },
     "@types/yargs": {
-      "version": "15.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-      "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+      "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "peer": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "peer": true
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -16661,9 +16661,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001241",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
-      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ=="
+      "version": "1.0.30001242",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
+      "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -17137,9 +17137,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
-      "integrity": "sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==",
       "peer": true
     },
     "debug": {
@@ -17365,9 +17365,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.765",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.765.tgz",
-      "integrity": "sha512-4NhcsfZYlr1x4FehYkK+R9CNNTOZ8vLcIu8Y1uWehxYp5r/jlCGAfBqChIubEfdtX+rBQpXx4yJuX/dzILH/nw=="
+      "version": "1.3.768",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.768.tgz",
+      "integrity": "sha512-I4UMZHhVSK2pwt8jOIxTi3GIuc41NkddtKT/hpuxp9GO5UWJgDKTBa4TACppbVAuKtKbMK6BhQZvT5tFF1bcNA=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -17836,9 +17836,9 @@
       }
     },
     "fastq": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -20480,9 +20480,9 @@
       }
     },
     "multiformats": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
-      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.2.tgz",
+      "integrity": "sha512-ca/Mvp8iQmCyLomEpMHRr0MgyBN3nTZ9YznOsoCBajyI51Y9TL8UNsX1CQXW/RGsYcto+OHmGelFZzsmdl66wA=="
     },
     "multihashes": {
       "version": "4.0.2",
@@ -22924,9 +22924,9 @@
       "peer": true
     },
     "stream-to-it": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.3.tgz",
-      "integrity": "sha512-xaK9EjPtLox5rrC7YLSBXSanTtUJN/lzJlMFvy9VaROmnyvy0U/X6m2uMhXPJRn3g3M9uOSIzTszW7BPiWSg9w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "requires": {
         "get-iterator": "^1.0.2"
       }
@@ -23901,9 +23901,9 @@
       }
     },
     "ws": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
-      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
+      "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==",
       "requires": {}
     },
     "xcode": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   },
   "homepage": "https://github.com/web3-storage/ipfs-car#readme",
   "dependencies": {
-    "@ipld/car": "^3.0.3",
+    "@ipld/car": "^3.1.4",
     "@vascosantos/ipfs-unixfs-exporter": "^8.0.0",
     "@vascosantos/ipfs-unixfs-importer": "^10.0.0",
     "@web-std/blob": "^2.1.1",
@@ -138,7 +138,7 @@
     "it-pipe": "^1.1.0",
     "meow": "^9.0.0",
     "move-file": "^2.0.0",
-    "multiformats": "^9.0.4",
+    "multiformats": "^9.1.2",
     "stream-to-it": "^0.2.3",
     "streaming-iterables": "^5.0.4",
     "uint8arrays": "^2.1.5"

--- a/src/blockstore/fs.ts
+++ b/src/blockstore/fs.ts
@@ -26,7 +26,7 @@ export class FsBlockStore implements Blockstore {
     }
   }
 
-  async put ({ cid, bytes }: { cid: CID, bytes: Uint8Array }) {
+  async put ({ cid, bytes }: Block) {
     if (!this._opened) {
       await this._open()
     }

--- a/src/blockstore/memory.ts
+++ b/src/blockstore/memory.ts
@@ -16,16 +16,16 @@ export class MemoryBlockStore implements Blockstore {
     }
   }
 
-  put ({ cid, bytes }: { cid: CID, bytes: Uint8Array }) {
+  put ({ cid, bytes }: Block) {
     this.store.set(cid.toString(), bytes)
     return Promise.resolve({ cid, bytes })
   }
 
-  get (cid: CID) : Promise<Block> {
+  get (cid: CID) : Promise<Block|undefined> {
     const bytes = this.store.get(cid.toString())
 
     if (!bytes) {
-      return Promise.reject(new Error(`No blocks for the given CID: ${cid.toString()}`))
+      return Promise.resolve(undefined)
     }
 
     return Promise.resolve({


### PR DESCRIPTION
This PR updated the interface types and also updated the dependencies

Not sure what changed, as this was working yesterday, but probably a mismatch of CID versions causing this.:

```
npm ERR! src/lib.js(107,9): error TS2322: Type 'MemoryBlockStore' is not assignable to type 'Blockstore'.
npm ERR!   Types of property 'put' are incompatible.
npm ERR!     Type '({ cid, bytes }: { cid: CID; bytes: Uint8Array; }) => Promise<{ cid: CID; bytes: Uint8Array; }>' is not assignable to type '(block: Block) => Promise<Block>'.
npm ERR!       Types of parameters '__0' and 'block' are incompatible.
npm ERR!         Type 'Block' is not assignable to type '{ cid: CID; bytes: Uint8Array; }'.
npm ERR!           Types of property 'cid' are incompatible.
npm ERR!             Type 'import("/Users/vsantos/work/pl/gh/web3.storage/node_modules/multiformats/types/cid").CID' is not assignable to type 'import("/Users/vsantos/work/pl/gh/web3.storage/packages/client/node_modules/ipfs-car/node_modules/multiformats/types/cid").CID'.
npm ERR!               Types have separate declarations of a private property 'asCID'.
npm ERR! src/lib.js(224,3): error TS2322: Type 'File & { cid: CID; }' is not assignable to type 'Web3File'.
npm ERR!   Types of property 'cid' are incompatible.
npm ERR!     Type 'import("/Users/vsantos/work/pl/gh/web3.storage/packages/client/node_modules/ipfs-car/node_modules/multiformats/types/cid").CID' is not assignable to type 'import("/Users/vsantos/work/pl/gh/web3.storage/node_modules/multiformats/types/cid").CID'.
npm ERR!       Types have separate declarations of a private property 'asCID'.
npm ERR! src/lib.js(254,59): error TS2322: Type 'MemoryBlockStore' is not assignable to type 'Blockstore'.
```

Note: this was reseting the package-lock in web3.storage monorepo