### PR TITLE
fix: empty input array

### DIFF
--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -13,7 +13,7 @@ import { MemoryBlockStore } from '../blockstore/memory'
 
 export async function pack ({ input, blockstore: userBlockstore }: { input: ImportCandidateStream, blockstore?: Blockstore }) {
   if (!input || (Array.isArray(input) && !input.length)) {
-    throw new Error('given input could not be parsed correctly')
+    throw new Error('missing input file(s)')
   }
 
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -12,6 +12,10 @@ import { Blockstore } from '../blockstore/index'
 import { MemoryBlockStore } from '../blockstore/memory'
 
 export async function pack ({ input, blockstore: userBlockstore }: { input: ImportCandidateStream, blockstore?: Blockstore }) {
+  if (!input || (Array.isArray(input) && !input.length)) {
+    throw new Error('given input could not be parsed correctly')
+  }
+
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()
 
   // Consume the source

--- a/src/pack/stream.ts
+++ b/src/pack/stream.ts
@@ -14,6 +14,10 @@ import { MemoryBlockStore } from '../blockstore/memory'
 
 // Node version of toCar with Node Stream Writable
 export async function packToStream ({ input, writable, blockstore: userBlockstore }: { input: string | Iterable<string> | AsyncIterable<string>, writable: Writable, blockstore?: Blockstore }) {
+  if (!input || (Array.isArray(input) && !input.length)) {
+    throw new Error('given input could not be parsed correctly')
+  }
+
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()
 
   // Consume the source
@@ -27,7 +31,7 @@ export async function packToStream ({ input, writable, blockstore: userBlockstor
       maxChunkSize: 262144,
       hasher: sha256,
       rawLeaves: true,
-      wrapWithDirectory: false // TODO: Set to true when not directory to keep names?
+      wrapWithDirectory: true
     })
   ))
 

--- a/test/pack/index.node.test.ts
+++ b/test/pack/index.node.test.ts
@@ -60,7 +60,7 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(2)
+        expect(files).to.have.lengthOf(3)
       })
 
       it('pack dir to car with filesystem output', async () => {
@@ -78,7 +78,7 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(2)
+        expect(files).to.have.lengthOf(3)
       })
 
       it('pack raw file to car with filesystem output', async () => {
@@ -96,10 +96,10 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(1)
+        expect(files).to.have.lengthOf(2)
 
         const rawOriginalContent = new Uint8Array(fs.readFileSync(`${__dirname}/../fixtures/file.raw`))
-        const rawContent = (await all(files[0].content()))[0]
+        const rawContent = (await all(files[files.length - 1].content()))[0]
 
         expect(equals(rawOriginalContent, rawContent)).to.eql(true)
       })
@@ -120,10 +120,10 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(1)
+        expect(files).to.have.lengthOf(2)
 
         const rawOriginalContent = new Uint8Array(fs.readFileSync(`${__dirname}/../fixtures/file.raw`))
-        const rawContent = (await all(files[0].content()))[0]
+        const rawContent = (await all(files[files.length - 1].content()))[0]
 
         expect(equals(rawOriginalContent, rawContent)).to.eql(true)
 
@@ -147,10 +147,10 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(1)
+        expect(files).to.have.lengthOf(2)
 
         const rawOriginalContent = new Uint8Array(fs.readFileSync(`${__dirname}/../fixtures/file.raw`))
-        const rawContent = (await all(files[0].content()))[0]
+        const rawContent = (await all(files[files.length - 1].content()))[0]
 
         expect(equals(rawOriginalContent, rawContent)).to.eql(true)
       })

--- a/test/pack/index.node.test.ts
+++ b/test/pack/index.node.test.ts
@@ -199,6 +199,21 @@ describe('pack', () => {
         expect(root.toString()).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
         await blockstore.close()
       })
+
+      it('should error to pack empty input', async () => {
+        const blockstore = new Blockstore()
+
+        try {
+          await pack({
+            input: [],
+            blockstore
+          })
+        } catch (err) {
+          expect(err).to.exist
+          return
+        }
+        throw new Error('pack should throw error with empty input')
+      })
     })
   })
 })


### PR DESCRIPTION
Fixes bug introduced by `wrapWithDirectory` (context: https://github.com/ipfs/js-ipfs-unixfs/issues/159)

Also adds `wrapWithDirectory` in `packToStream` which I previously missed 🤦🏼‍♂️ 