### PR TITLE
Wait until all blocks have been written before returning

### DIFF
--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -52,7 +52,7 @@ export async function pack ({ input, blockstore: userBlockstore, hasher, maxChun
     writer.put(block)
   }
 
-  writer.close()
+  await writer.close()
 
   if (!userBlockstore) {
     await blockstore.close()


### PR DESCRIPTION
This appears to have been the source of the error I was encountering
with web3.storage here:

https://github.com/web3-storage/web3.storage/issues/302