### PR TITLE
fix: race condition using pack to blob

### DIFF
--- a/src/pack/blob.ts
+++ b/src/pack/blob.ts
@@ -19,11 +19,12 @@ export async function packToBlob ({ input, blockstore: userBlockstore, hasher, m
     wrapWithDirectory
   })
 
+  const carParts = await all(out)
+
   if (!userBlockstore) {
     await blockstore.close()
   }
 
-  const carParts = await all(out)
   const car = new Blob(carParts, {
     type: 'application/car',
   })


### PR DESCRIPTION
Between versions 0.5.4 and 0.5.5 of `ipfs-car` we introduced a race condition that seems only to exist with a service worker, as this was caught trying to update `ipfs-car` in `web3.storage` worker API.

This is the relevant commit: https://github.com/web3-storage/ipfs-car/commit/42d5dde40d2d65f1bffa18432f741088a380c065

The change added backpressure to pack, which allowed the pack to only iterate the blockstore when reads start, instead of right away. `packToBlob` relies on `pack` which means it also has this feature, and will consume all the data to create the Blob in memory. However, `blockstore.close` in `packtoBlob` could be called earlier than the blocks were actually iterated, causing an empty CAR file to be created