### PR TITLE
fix:! do not wrap with directory by default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ import { MemoryBlockStore } from 'ipfs-car/blockstore/memory' // You can also us
 const { root, out } = await pack({
   input: [new Uint8Array([21, 31, 41])],
   blockstore: new MemoryBlockStore(),
-  wrapWithDirectory: true // Wraps input into a directory. Defaults to `true`
+  wrapWithDirectory: false // Wraps inputs with paths into a directory. Defaults to `false`
   maxChunkSize: 262144 // The maximum block size in bytes. Defaults to `262144`. Max safe value is < 1048576 (1MiB)
 })
 
@@ -115,6 +115,21 @@ const carParts = []
 for await (const part of out) {
   carParts.push(part)
 }
+```
+
+When using `wrapWithDirectory` functionality, a path for the files needs to be provided, in order to have DAG links properly created. See the example as follows:
+
+```js
+import { pack } from 'ipfs-car/pack'
+import { MemoryBlockStore } from 'ipfs-car/blockstore/memory' // You can also use the `level-blockstore` module
+
+const { root, out } = await pack({
+  input: [{
+    path: 'file.txt',
+    content: new Uint8Array([21, 31, 41])
+  }],
+  wrapWithDirectory: true
+})
 ```
 
 ### `ipfs-car/pack/blob`

--- a/package-lock.json
+++ b/package-lock.json
@@ -821,9 +821,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.2.tgz",
-      "integrity": "sha512-TbG4TOx9hng8FKxaVrCisdaxKxqEwJ3zwHoCWXZ0Jw6mnvTInpaB99/2Cy4+XxpXtjNv9/TgfGSvZFyfV/t8Fw=="
+      "version": "16.7.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
+      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -1796,9 +1796,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.818",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.818.tgz",
-      "integrity": "sha512-c/Z9gIr+jDZAR9q+mn40hEc1NharBT+8ejkarjbCDnBNFviI6hvcC5j2ezkAXru//bTnQp5n6iPi0JA83Tla1Q==",
+      "version": "1.3.822",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.822.tgz",
+      "integrity": "sha512-k7jG5oYYHxF4jx6PcqwHX3JVME/OjzolqOZiIogi9xtsfsmTjTdie4x88OakYFPEa8euciTgCCzvVNwvmjHb1Q==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
@@ -2630,9 +2630,9 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.4.tgz",
-      "integrity": "sha512-5ARPcTtDGgFK6jPYWAitgDTxIjEcrqz3+ReIPuFZCcekglt2jS8osoZYSLNtpGDtjGevQtaJAgce+BQDY3ymBA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.5.tgz",
+      "integrity": "sha512-D8Z3EsegLxOBc2L8oMyZw/FRUDQG0ZZAaBRfzMrRsGnj7RFI7OlV1hU54aMeDxFYFviKNnUdsyEFI2zUWmgGvw==",
       "dependencies": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
@@ -2643,9 +2643,9 @@
       }
     },
     "node_modules/ipfs-unixfs-exporter": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.4.tgz",
-      "integrity": "sha512-5G6IIAaZlLuK7lFW17u57INnSkqaaZbIqXQWPqKJUncmK3Sq7+m3Yl9IzyP5gsLTM/H/AIPD7xbTqIeuIz+PHQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.5.tgz",
+      "integrity": "sha512-H/fBcBHO4kMivj2JyqwVmp90JIxKEsRpgkyifkZxmslttcTgivrOM3s7xeLuj6EkchkqyHS9+wurdv83WFOFpQ==",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.4",
         "@ipld/dag-pb": "^2.0.2",
@@ -2653,7 +2653,7 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.4",
+        "ipfs-unixfs": "^6.0.5",
         "it-last": "^1.0.5",
         "multiformats": "^9.4.2",
         "uint8arrays": "^3.0.0"
@@ -2664,9 +2664,9 @@
       }
     },
     "node_modules/ipfs-unixfs-importer": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.4.tgz",
-      "integrity": "sha512-RCl3f6/5zRT6716UYuRZET5iWafi9gvRPmgHhWE0Pmco74T2h/VPNHCgj6Noo85fVCNG5KsGBL38uzONO85MNA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.5.tgz",
+      "integrity": "sha512-+Xxqu7WKC/cFd/IP5bCPw4E29CybU0k/exxNJCCn/QDrSm+o25Dz4IFCLc9jXvffi9Za8gCMywZFeM2HbB5Dyg==",
       "dependencies": {
         "@ipld/dag-pb": "^2.0.2",
         "@multiformats/murmur3": "^1.0.3",
@@ -2674,7 +2674,7 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.4",
+        "ipfs-unixfs": "^6.0.5",
         "it-all": "^1.0.5",
         "it-batch": "^1.0.8",
         "it-first": "^1.0.6",
@@ -2690,9 +2690,9 @@
       }
     },
     "node_modules/ipfs-utils": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.5.tgz",
-      "integrity": "sha512-qjERTUy0iXPw5LRPA1OQLzYPjdYb7JQenihYaE0L+yA4NMoC9qhGVrYUqU8yaV0Iu+zk7i6BxoNwg8beWsqjbg==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.6.tgz",
+      "integrity": "sha512-V/cwb6113DrDhrjDTWImA6+zmJbpdbUkxdxmEQO7it8ykV76bBmzU1ZXSM0QR0qxGy9VW8dkUlPAC2K10VgSmw==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "any-signal": "^2.1.0",
@@ -2707,7 +2707,7 @@
         "nanoid": "^3.1.20",
         "native-abort-controller": "^1.0.3",
         "native-fetch": "^3.0.0",
-        "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
+        "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
         "react-native-fetch-api": "^2.0.0",
         "stream-to-it": "^0.2.2"
       }
@@ -3659,9 +3659,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-Kjg/XxYOFFUi0h/FwMOeb6RoroiZ+P1yOfya6NK7h3dNhahrJx1r2XIT3ge4ZQvJM86mdjNA+W5phqRQh7DwCg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -3830,6 +3830,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+      "license": "MIT",
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -5236,12 +5237,12 @@
       }
     },
     "node_modules/sirv": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.16.tgz",
-      "integrity": "sha512-x56DISeIgSUGVJrQS3mwu+UvtnzHenKDFBQL+UlAswxwk9b2Cpc0KGVvftoIJZgweOOXbMZzyXFYgVElOuSI1Q==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.17.tgz",
+      "integrity": "sha512-qx9go5yraB7ekT7bCMqUHJ5jEaOC/GXBxUWv+jeWnb7WzHUFdcQPGWk7YmAwFBaQBrogpuSqd/azbC2lZRqqmw==",
       "dev": true,
       "dependencies": {
-        "@polka/url": "^1.0.0-next.19",
+        "@polka/url": "^1.0.0-next.20",
         "mime": "^2.3.1",
         "totalist": "^1.0.0"
       },
@@ -5250,9 +5251,9 @@
       }
     },
     "node_modules/sirv/node_modules/@polka/url": {
-      "version": "1.0.0-next.19",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.19.tgz",
-      "integrity": "sha512-kHR9OHwP9WLpyC0i/WCAQCgf5hXkR9C+/21qxmrn+YwRlDRnBlqrcrFpXxhJTA9LDHJWa/FjoO2LJ12q8iWlEQ==",
+      "version": "1.0.0-next.20",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.20.tgz",
+      "integrity": "sha512-88p7+M0QGxKpmnkfXjS4V26AnoC/eiqZutE8GLdaI5X12NY75bXSdTY9NkmYb2Xyk1O+MmkuO6Frmsj84V6I8Q==",
       "dev": true
     },
     "node_modules/slash": {
@@ -5962,9 +5963,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6266,9 +6267,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -7085,9 +7086,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.2.tgz",
-      "integrity": "sha512-TbG4TOx9hng8FKxaVrCisdaxKxqEwJ3zwHoCWXZ0Jw6mnvTInpaB99/2Cy4+XxpXtjNv9/TgfGSvZFyfV/t8Fw=="
+      "version": "16.7.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
+      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7836,9 +7837,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.818",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.818.tgz",
-      "integrity": "sha512-c/Z9gIr+jDZAR9q+mn40hEc1NharBT+8ejkarjbCDnBNFviI6hvcC5j2ezkAXru//bTnQp5n6iPi0JA83Tla1Q==",
+      "version": "1.3.822",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.822.tgz",
+      "integrity": "sha512-k7jG5oYYHxF4jx6PcqwHX3JVME/OjzolqOZiIogi9xtsfsmTjTdie4x88OakYFPEa8euciTgCCzvVNwvmjHb1Q==",
       "dev": true
     },
     "emoji-regex": {
@@ -8040,9 +8041,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -8457,18 +8458,18 @@
       }
     },
     "ipfs-unixfs": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.4.tgz",
-      "integrity": "sha512-5ARPcTtDGgFK6jPYWAitgDTxIjEcrqz3+ReIPuFZCcekglt2jS8osoZYSLNtpGDtjGevQtaJAgce+BQDY3ymBA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.5.tgz",
+      "integrity": "sha512-D8Z3EsegLxOBc2L8oMyZw/FRUDQG0ZZAaBRfzMrRsGnj7RFI7OlV1hU54aMeDxFYFviKNnUdsyEFI2zUWmgGvw==",
       "requires": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.4.tgz",
-      "integrity": "sha512-5G6IIAaZlLuK7lFW17u57INnSkqaaZbIqXQWPqKJUncmK3Sq7+m3Yl9IzyP5gsLTM/H/AIPD7xbTqIeuIz+PHQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.5.tgz",
+      "integrity": "sha512-H/fBcBHO4kMivj2JyqwVmp90JIxKEsRpgkyifkZxmslttcTgivrOM3s7xeLuj6EkchkqyHS9+wurdv83WFOFpQ==",
       "requires": {
         "@ipld/dag-cbor": "^6.0.4",
         "@ipld/dag-pb": "^2.0.2",
@@ -8476,16 +8477,16 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.4",
+        "ipfs-unixfs": "^6.0.5",
         "it-last": "^1.0.5",
         "multiformats": "^9.4.2",
         "uint8arrays": "^3.0.0"
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.4.tgz",
-      "integrity": "sha512-RCl3f6/5zRT6716UYuRZET5iWafi9gvRPmgHhWE0Pmco74T2h/VPNHCgj6Noo85fVCNG5KsGBL38uzONO85MNA==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.5.tgz",
+      "integrity": "sha512-+Xxqu7WKC/cFd/IP5bCPw4E29CybU0k/exxNJCCn/QDrSm+o25Dz4IFCLc9jXvffi9Za8gCMywZFeM2HbB5Dyg==",
       "requires": {
         "@ipld/dag-pb": "^2.0.2",
         "@multiformats/murmur3": "^1.0.3",
@@ -8493,7 +8494,7 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.4",
+        "ipfs-unixfs": "^6.0.5",
         "it-all": "^1.0.5",
         "it-batch": "^1.0.8",
         "it-first": "^1.0.6",
@@ -8505,9 +8506,9 @@
       }
     },
     "ipfs-utils": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.5.tgz",
-      "integrity": "sha512-qjERTUy0iXPw5LRPA1OQLzYPjdYb7JQenihYaE0L+yA4NMoC9qhGVrYUqU8yaV0Iu+zk7i6BxoNwg8beWsqjbg==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.6.tgz",
+      "integrity": "sha512-V/cwb6113DrDhrjDTWImA6+zmJbpdbUkxdxmEQO7it8ykV76bBmzU1ZXSM0QR0qxGy9VW8dkUlPAC2K10VgSmw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^2.1.0",
@@ -8522,7 +8523,7 @@
         "nanoid": "^3.1.20",
         "native-abort-controller": "^1.0.3",
         "native-fetch": "^3.0.0",
-        "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
+        "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
         "react-native-fetch-api": "^2.0.0",
         "stream-to-it": "^0.2.2"
       }
@@ -9220,9 +9221,9 @@
       }
     },
     "mocha": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.0.tgz",
-      "integrity": "sha512-Kjg/XxYOFFUi0h/FwMOeb6RoroiZ+P1yOfya6NK7h3dNhahrJx1r2XIT3ge4ZQvJM86mdjNA+W5phqRQh7DwCg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -9347,8 +9348,7 @@
       }
     },
     "node-fetch": {
-      "version": "npm:@achingbrain/node-fetch@2.6.7",
-      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+      "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
     },
     "node-preload": {
@@ -10387,20 +10387,20 @@
       }
     },
     "sirv": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.16.tgz",
-      "integrity": "sha512-x56DISeIgSUGVJrQS3mwu+UvtnzHenKDFBQL+UlAswxwk9b2Cpc0KGVvftoIJZgweOOXbMZzyXFYgVElOuSI1Q==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.17.tgz",
+      "integrity": "sha512-qx9go5yraB7ekT7bCMqUHJ5jEaOC/GXBxUWv+jeWnb7WzHUFdcQPGWk7YmAwFBaQBrogpuSqd/azbC2lZRqqmw==",
       "dev": true,
       "requires": {
-        "@polka/url": "^1.0.0-next.19",
+        "@polka/url": "^1.0.0-next.20",
         "mime": "^2.3.1",
         "totalist": "^1.0.0"
       },
       "dependencies": {
         "@polka/url": {
-          "version": "1.0.0-next.19",
-          "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.19.tgz",
-          "integrity": "sha512-kHR9OHwP9WLpyC0i/WCAQCgf5hXkR9C+/21qxmrn+YwRlDRnBlqrcrFpXxhJTA9LDHJWa/FjoO2LJ12q8iWlEQ==",
+          "version": "1.0.0-next.20",
+          "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.20.tgz",
+          "integrity": "sha512-88p7+M0QGxKpmnkfXjS4V26AnoC/eiqZutE8GLdaI5X12NY75bXSdTY9NkmYb2Xyk1O+MmkuO6Frmsj84V6I8Q==",
           "dev": true
         }
       }
@@ -10938,9 +10938,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "uint8arrays": {
@@ -11182,9 +11182,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,20 +88,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -127,12 +127,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.15.0",
@@ -168,141 +168,141 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -317,14 +317,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -420,32 +420,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -454,9 +454,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@ipld/car": {
-      "version": "3.1.16",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.16.tgz",
-      "integrity": "sha512-LvIXl7BYmy8em1PFB1l2Iu3/bFHYHy3h3x7HcDi9veoGSYi70dAIthJsXgkoYoGfRSLONR1FDjaoFjbbXk87Qw==",
+      "version": "3.1.17",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.17.tgz",
+      "integrity": "sha512-pKC1WbNcac+1hv+gA1dqa6H1/8XujIrKJT0o3L1vQ1fB+w/fg3Dk6BVOQ+bMp9YkbbBok32R5VU8lbnpG5T6sQ==",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.0",
         "@types/varint": "^6.0.0",
@@ -499,9 +499,9 @@
       }
     },
     "node_modules/@ipld/dag-cbor": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.9.tgz",
-      "integrity": "sha512-Kj8K8z2YMhupPJMHAn3jSVgGl/V7gT3Eki1dCE4bVhbli+vHS6lLObZXAcrTXMMHHYFmkSoOFdvwoYu5AU7lBA==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.11.tgz",
+      "integrity": "sha512-W9hpFAFS7+n0orqlq7w06ADeORealpTJ92jQZBZDywYMjOlcVfVKKKkVgCq/pUbwlSRqip+9kgzEvdfd5N3zcQ==",
       "dependencies": {
         "cborg": "^1.2.1",
         "multiformats": "^9.0.0"
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@multiformats/murmur3": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.0.3.tgz",
-      "integrity": "sha512-pd56A/Bxu4FnZ55kQ1izk3XQgBZXdn4tQq/kvNxR0vtEJNbW7NJTnYDhnRJSH94OxycsOMDoKh6flS2VkFVTYg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.0.4.tgz",
+      "integrity": "sha512-skwYQeIVDxUhqJngCjzC9ZV3cSYkrHsyq2T4DDiMR2QAPkyv6JsKMCXj7FEhrgDqx5fB4Bkxv6+VLVNlDBbzJQ==",
       "dependencies": {
         "multiformats": "^9.4.1",
         "murmurhash3js-revisited": "^3.0.0"
@@ -788,9 +788,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
-      "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
+      "version": "4.2.22",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
+      "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
       "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -821,9 +821,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
-      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg=="
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+      "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@types/sinon": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.2.tgz",
-      "integrity": "sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.4.tgz",
+      "integrity": "sha512-fOYjrxQv8zJsqOY6V6ecP4eZhQBxtY80X0er1VVnUIAIZo74jHm8e1vguG5Yt4Iv8W2Wr7TgibB8MfRe32k9pA==",
       "dev": true,
       "dependencies": {
         "@sinonjs/fake-timers": "^7.1.0"
@@ -915,9 +915,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -927,9 +927,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
-      "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -970,9 +970,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.0.tgz",
-      "integrity": "sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
-      "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1141,9 +1141,9 @@
       }
     },
     "node_modules/blob-to-it": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.2.tgz",
-      "integrity": "sha512-yD8tikfTlUGEOSHExz4vDCIQFLaBPXIL0KcxGQt9RbwMVXBEh+jokdJyStvTXPgWrdKfwgk7RX8GPsgrYzsyng==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.3.tgz",
+      "integrity": "sha512-3bCrqSWG2qWwoIeF6DUJeuW/1isjx7DUhqZn9GpWlK8SVeqcjP+zw4yujdV0bVaqtggk6CUgtu87jfwHi5g7Zg==",
       "dependencies": {
         "browser-readablestream-to-it": "^1.0.2"
       }
@@ -1181,16 +1181,16 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.16.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
-      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001251",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.811",
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1296,9 +1296,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001252",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+      "version": "1.0.30001261",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
+      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -1306,9 +1306,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.5.0.tgz",
-      "integrity": "sha512-3t1+s45x5LiACi39HDiSubPZiKXU2rCreu0oi5A1nccQNDHnprCh9ZQKN1Za3eookOmL03e9oKEZ+LJs0iTE8A==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.5.1.tgz",
+      "integrity": "sha512-GKCylZR7os3Q9X+U3DiARfeFKQUdcZMAP8EKFSE91YbhJsxV71Z6PMOT2osVWprb+iWf6viyqD7peEkK0QCAAw==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -1433,44 +1433,21 @@
       }
     },
     "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -1501,12 +1478,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/colorette": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
     },
     "node_modules/commander": {
@@ -1574,9 +1545,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1796,9 +1767,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.822",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.822.tgz",
-      "integrity": "sha512-k7jG5oYYHxF4jx6PcqwHX3JVME/OjzolqOZiIogi9xtsfsmTjTdie4x88OakYFPEa8euciTgCCzvVNwvmjHb1Q==",
+      "version": "1.3.851",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.851.tgz",
+      "integrity": "sha512-Ak970eGtRSoHTaJkoDjdkeXYetbwm5Bl9pN/nPOQ3QzLfw1EWRjReOlWUra6o58SVgxfpwOT9U2P1BUXoJ57dw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1838,21 +1809,22 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-      "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.3",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
+        "is-regex": "^1.1.4",
+        "is-string": "^1.0.7",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -2023,9 +1995,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
-      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2233,6 +2205,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -2473,11 +2460,11 @@
       }
     },
     "node_modules/idb-keyval": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.3.tgz",
-      "integrity": "sha512-N9HbCK/FaXSRVI+k6Xq4QgWxbcZRUv+SfG1y7HJ28JdV8yEJu6k+C/YLea7npGckX2DQJeEVuMc4bKOBeU/2LQ==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.5.tgz",
+      "integrity": "sha512-J1utxYWQokYjy01LvDQ7WmiAtZCGUSkVi9EIBfUSyLOr/BesnMIxNGASTh9A1LzeISSjSqEPsfFdTss7EE7ofQ==",
       "dependencies": {
-        "safari-14-idb-fix": "^1.0.4"
+        "safari-14-idb-fix": "^1.0.6"
       }
     },
     "node_modules/ieee754": {
@@ -2541,12 +2528,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/interface-blockstore": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-1.0.1.tgz",
-      "integrity": "sha512-OYo8QXdM1UgIxftFKBgD+yM6tvHbtPu7TTgTPJS4VXY4xBwOM2sJTH8Mhe/EOGJDLXc0D0mscmlWyEhc3GSiJA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-1.0.2.tgz",
+      "integrity": "sha512-e8rHqaBSOsBPpSaB+wwVa9mR5ntU+t1yzXpOFC16cSKCNsV+h6n8SjekPQcdODVBN2h8t45CsOqRAnUfm1guEw==",
       "dependencies": {
         "err-code": "^3.0.1",
-        "interface-store": "^0.1.1",
+        "interface-store": "^1.0.2",
         "it-all": "^1.0.5",
         "it-drain": "^1.0.4",
         "it-filter": "^1.0.2",
@@ -2555,12 +2542,12 @@
       }
     },
     "node_modules/interface-datastore": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-5.1.2.tgz",
-      "integrity": "sha512-nRFl19/IkilNzuPdCUJHejyJCZrVAk4lIRcRXJkekuTdaiagIEnCd9GfmTTQlo2afiVISk8Iy/PxSgnfmrdEIw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-5.2.0.tgz",
+      "integrity": "sha512-nthO4C4BMJM2j9x/mT2KFa/g/sbcY8yf9j/kOBgli3u5mq9ZdPvQyDxi0OhKzr4JmoM81OYh5xcFjyebquqwvA==",
       "dependencies": {
         "err-code": "^3.0.1",
-        "interface-store": "^0.1.1",
+        "interface-store": "^1.0.2",
         "ipfs-utils": "^8.1.2",
         "it-all": "^1.0.2",
         "it-drain": "^1.0.1",
@@ -2571,9 +2558,9 @@
       }
     },
     "node_modules/interface-store": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-0.1.1.tgz",
-      "integrity": "sha512-ynnjIOybDZc0Brep3HHSa2RVlo/M5g7kuL/leui7o21EusKcLJS170vCJ8rliisc3c4jyd9ao5PthkGlBaX29g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-1.0.2.tgz",
+      "integrity": "sha512-rUBLYsgoWwxuUpnQoSUr+DR/3dH3reVeIu5aOHFZK31lAexmb++kR6ZECNRgrx6WvoaM3Akdo0A7TDrqgCzZaQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -2597,25 +2584,25 @@
       }
     },
     "node_modules/ipfs-core-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.7.0.tgz",
-      "integrity": "sha512-tWJ5aJPPKeMHccPIx9EEXRZl1vsgu4rJpSPMFjjLz2JkGr6tSyCkxCOvsdSTsscfITx+NQcvcyPQb39O12fGOw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.7.3.tgz",
+      "integrity": "sha512-FkmOlqhEf3yG0K8Qt7We7kqA0xKjj8pe0dmNK593I3cgMP0MQS/xjMj1CXVdGeZc5Nn5CJ+TsuQydPbJ+7Y8eQ==",
       "dependencies": {
-        "interface-datastore": "^5.0.0",
+        "interface-datastore": "^5.2.0",
         "multiaddr": "^10.0.0",
         "multiformats": "^9.4.1"
       }
     },
     "node_modules/ipfs-core-utils": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.10.2.tgz",
-      "integrity": "sha512-xyTqw9epOJZsa2opFp9L+7Ul/xRmWnqT8uiFW51O40jXNo95MLPgZJAOH4W5FgOR/ckpHHse+Yvqab+2YXsH3A==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.10.5.tgz",
+      "integrity": "sha512-WPRbMkbn/99pKMF3h8x1/c19+eTXVWOZu1+cmlc3NLR6gMlCd8KNpcq9OCAvs9G1JHx3w/FbEWHnqJm0TJMvrw==",
       "dependencies": {
         "any-signal": "^2.1.2",
         "blob-to-it": "^1.0.1",
         "browser-readablestream-to-it": "^1.0.1",
         "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.7.0",
+        "ipfs-core-types": "^0.7.3",
         "ipfs-unixfs": "^6.0.3",
         "ipfs-utils": "^8.1.4",
         "it-all": "^1.0.4",
@@ -2630,9 +2617,9 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.5.tgz",
-      "integrity": "sha512-D8Z3EsegLxOBc2L8oMyZw/FRUDQG0ZZAaBRfzMrRsGnj7RFI7OlV1hU54aMeDxFYFviKNnUdsyEFI2zUWmgGvw==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.6.tgz",
+      "integrity": "sha512-gTkjYKXuHnqIf6EFfS+ESaYEl3I3aaQQ0UX8MhpNzreMLEuMnuqpoI/uLLllTZa31WRplKixabbpRTSmTYRNwA==",
       "dependencies": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
@@ -2643,9 +2630,9 @@
       }
     },
     "node_modules/ipfs-unixfs-exporter": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.5.tgz",
-      "integrity": "sha512-H/fBcBHO4kMivj2JyqwVmp90JIxKEsRpgkyifkZxmslttcTgivrOM3s7xeLuj6EkchkqyHS9+wurdv83WFOFpQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.6.tgz",
+      "integrity": "sha512-PkKB+hTbHhKLqgj0PqSNQ/n7dKsu/lC29jLK8nUXOX4EM6c+RnedohdCY7khT10/hfC7oADbpFs/QJfuH2DaAg==",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.4",
         "@ipld/dag-pb": "^2.0.2",
@@ -2653,7 +2640,7 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.5",
+        "ipfs-unixfs": "^6.0.6",
         "it-last": "^1.0.5",
         "multiformats": "^9.4.2",
         "uint8arrays": "^3.0.0"
@@ -2664,9 +2651,9 @@
       }
     },
     "node_modules/ipfs-unixfs-importer": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.5.tgz",
-      "integrity": "sha512-+Xxqu7WKC/cFd/IP5bCPw4E29CybU0k/exxNJCCn/QDrSm+o25Dz4IFCLc9jXvffi9Za8gCMywZFeM2HbB5Dyg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.6.tgz",
+      "integrity": "sha512-FgzODqg4pvToEMZ88mFkHcU0s25CljmnqX2VX7K/VQDckiZIxhIiUTQRqQg/C7Em4uCzVp8YCxKUvl++w6kvNg==",
       "dependencies": {
         "@ipld/dag-pb": "^2.0.2",
         "@multiformats/murmur3": "^1.0.3",
@@ -2674,7 +2661,7 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.5",
+        "ipfs-unixfs": "^6.0.6",
         "it-all": "^1.0.5",
         "it-batch": "^1.0.8",
         "it-first": "^1.0.6",
@@ -2782,9 +2769,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2821,12 +2808,12 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -2844,9 +2831,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.2.tgz",
+      "integrity": "sha512-ZZTOjRcDjuAAAv2cTBQP/lL59ZTArx77+7UzHdWW/XB1mrfp7DEaVpKmZ0XIzx+M7AxfhKcqV+nMetUQmFifwg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3025,11 +3012,11 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.7.tgz",
-      "integrity": "sha512-VxlpTBGknhQ3o7YiVjIhdLU6+oD8dPz/79vvvH4F+S/c8608UCVa9fgDpa1kZgFoUST2DCgacc70UszKgzKuvA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
       "dependencies": {
-        "available-typed-arrays": "^1.0.4",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
@@ -3108,9 +3095,9 @@
       }
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3258,9 +3245,9 @@
       "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ=="
     },
     "node_modules/it-glob": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.13.tgz",
-      "integrity": "sha512-0Hcd5BraJUPzL28NWiFbdNrcdyNxNTKKdU3sjdFiYynNTQpwlG2UKW31X7bp+XhJwux/oPzIquo5ioztVmc2RQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.14.tgz",
+      "integrity": "sha512-TKKzs9CglbsihSpcwJPXN5DBUssu4akRzPlp8QJRCoLrKoaOpyY2V1qDlxx+UMivn0i114YyTd4AawWl7eqIdw==",
       "dependencies": {
         "@types/minimatch": "^3.0.4",
         "minimatch": "^3.0.4"
@@ -3500,9 +3487,9 @@
       "dev": true
     },
     "node_modules/map-obj": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "engines": {
         "node": ">=8"
       },
@@ -3659,16 +3646,16 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -3679,12 +3666,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -3703,9 +3689,9 @@
       }
     },
     "node_modules/mocha/node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -3738,9 +3724,9 @@
       }
     },
     "node_modules/mri": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
-      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -3773,9 +3759,9 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.6.tgz",
-      "integrity": "sha512-ngZRO82P7mPvw/3gu5NQ2QiUJGYTS0LAxvQnEAlWCJakvn7YpK2VAd9JWM5oosYUeqoVbkylH/FsqRc4fc2+ag=="
+      "version": "9.4.8",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.8.tgz",
+      "integrity": "sha512-EOJL02/kv+FD5hoItMhKgkYUUruJYMYFq4NQ6YkCh3jVQ5CuHo+OKdHeR50hAxEQmXQ9yvrM9BxLIk42xtfwnQ=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -3785,10 +3771,16 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "dev": true
+    },
     "node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.28.tgz",
+      "integrity": "sha512-gSu9VZ2HtmoKYe/lmyPFES5nknFrHa+/DT9muUFWFMi6Jh9E1I7bkvlQ8xxf1Kos9pi9o8lBnIOkatMhKX/YUw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3797,9 +3789,9 @@
       }
     },
     "node_modules/native-abort-controller": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
-      "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
+      "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
       "peerDependencies": {
         "abort-controller": "*"
       }
@@ -3848,9 +3840,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -3918,9 +3910,9 @@
       }
     },
     "node_modules/nyc/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3946,15 +3938,6 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3998,27 +3981,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/nyc/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nyc/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -4176,9 +4145,9 @@
       }
     },
     "node_modules/ora/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -4220,12 +4189,12 @@
       }
     },
     "node_modules/ora/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -5109,9 +5078,9 @@
       }
     },
     "node_modules/safari-14-idb-fix": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.4.tgz",
-      "integrity": "sha512-4+Y2baQdgJpzu84d0QjySl70Kyygzf0pepVg8NVg4NnQEPpfC91fAn0baNvtStlCjUUxxiu0BOMiafa98fRRuA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
+      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5201,9 +5170,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
+      "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==",
       "dev": true
     },
     "node_modules/sinon": {
@@ -5331,9 +5300,9 @@
       "dev": true
     },
     "node_modules/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -5386,37 +5355,38 @@
       }
     },
     "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -5461,12 +5431,12 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.0.tgz",
-      "integrity": "sha512-UhDTSnGF1dc0DRbUqr1aXwNoY3RgVkSWG8BrpnuFIxhP57IqbS7IRta2Gfiavds4yCxc5+fEAVVOgBZWnYkvzg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^6.0.0"
+        "ansi-regex": "^6.0.1"
       },
       "engines": {
         "node": ">=12"
@@ -5963,9 +5933,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6038,9 +6008,9 @@
       }
     },
     "node_modules/v8-to-istanbul": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
-      "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -6154,31 +6124,22 @@
       "dev": true
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.6.tgz",
-      "integrity": "sha512-DdY984dGD5sQ7Tf+x1CkXzdg85b9uEel6nr4UkFg1LoE9OXv3uRuZhe5CoWdawhGACeFpEZXH8fFLQnDhbpm/Q==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
       "dependencies": {
-        "available-typed-arrays": "^1.0.4",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.6"
+        "is-typed-array": "^1.1.7"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/workerpool": {
@@ -6205,44 +6166,21 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -6267,9 +6205,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -6366,50 +6304,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -6478,20 +6372,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -6509,20 +6403,20 @@
       }
     },
     "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+      "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0",
+        "@babel/types": "^7.15.4",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.15.0",
@@ -6540,111 +6434,111 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+      "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.6"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
@@ -6653,14 +6547,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-      "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/highlight": {
@@ -6725,43 +6619,43 @@
       }
     },
     "@babel/parser": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-      "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+      "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.9",
@@ -6784,9 +6678,9 @@
       }
     },
     "@ipld/car": {
-      "version": "3.1.16",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.16.tgz",
-      "integrity": "sha512-LvIXl7BYmy8em1PFB1l2Iu3/bFHYHy3h3x7HcDi9veoGSYi70dAIthJsXgkoYoGfRSLONR1FDjaoFjbbXk87Qw==",
+      "version": "3.1.17",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.17.tgz",
+      "integrity": "sha512-pKC1WbNcac+1hv+gA1dqa6H1/8XujIrKJT0o3L1vQ1fB+w/fg3Dk6BVOQ+bMp9YkbbBok32R5VU8lbnpG5T6sQ==",
       "requires": {
         "@ipld/dag-cbor": "^6.0.0",
         "@types/varint": "^6.0.0",
@@ -6795,9 +6689,9 @@
       }
     },
     "@ipld/dag-cbor": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.9.tgz",
-      "integrity": "sha512-Kj8K8z2YMhupPJMHAn3jSVgGl/V7gT3Eki1dCE4bVhbli+vHS6lLObZXAcrTXMMHHYFmkSoOFdvwoYu5AU7lBA==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.11.tgz",
+      "integrity": "sha512-W9hpFAFS7+n0orqlq7w06ADeORealpTJ92jQZBZDywYMjOlcVfVKKKkVgCq/pUbwlSRqip+9kgzEvdfd5N3zcQ==",
       "requires": {
         "cborg": "^1.2.1",
         "multiformats": "^9.0.0"
@@ -6889,9 +6783,9 @@
       "dev": true
     },
     "@multiformats/murmur3": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.0.3.tgz",
-      "integrity": "sha512-pd56A/Bxu4FnZ55kQ1izk3XQgBZXdn4tQq/kvNxR0vtEJNbW7NJTnYDhnRJSH94OxycsOMDoKh6flS2VkFVTYg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.0.4.tgz",
+      "integrity": "sha512-skwYQeIVDxUhqJngCjzC9ZV3cSYkrHsyq2T4DDiMR2QAPkyv6JsKMCXj7FEhrgDqx5fB4Bkxv6+VLVNlDBbzJQ==",
       "requires": {
         "multiformats": "^9.4.1",
         "murmurhash3js-revisited": "^3.0.0"
@@ -7053,9 +6947,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
-      "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
+      "version": "4.2.22",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
+      "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
@@ -7086,9 +6980,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz",
-      "integrity": "sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg=="
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+      "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7106,9 +7000,9 @@
       }
     },
     "@types/sinon": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.2.tgz",
-      "integrity": "sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.4.tgz",
+      "integrity": "sha512-fOYjrxQv8zJsqOY6V6ecP4eZhQBxtY80X0er1VVnUIAIZo74jHm8e1vguG5Yt4Iv8W2Wr7TgibB8MfRe32k9pA==",
       "dev": true,
       "requires": {
         "@sinonjs/fake-timers": "^7.1.0"
@@ -7177,15 +7071,15 @@
       }
     },
     "acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
       "dev": true
     },
     "acorn-walk": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
-      "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
     "agent-base": {
@@ -7214,9 +7108,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.0.tgz",
-      "integrity": "sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true
     },
     "ansi-styles": {
@@ -7304,9 +7198,9 @@
       "dev": true
     },
     "available-typed-arrays": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
-      "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -7335,9 +7229,9 @@
       }
     },
     "blob-to-it": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.2.tgz",
-      "integrity": "sha512-yD8tikfTlUGEOSHExz4vDCIQFLaBPXIL0KcxGQt9RbwMVXBEh+jokdJyStvTXPgWrdKfwgk7RX8GPsgrYzsyng==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.3.tgz",
+      "integrity": "sha512-3bCrqSWG2qWwoIeF6DUJeuW/1isjx7DUhqZn9GpWlK8SVeqcjP+zw4yujdV0bVaqtggk6CUgtu87jfwHi5g7Zg==",
       "requires": {
         "browser-readablestream-to-it": "^1.0.2"
       }
@@ -7372,16 +7266,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
-      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.1.tgz",
+      "integrity": "sha512-aLD0ZMDSnF4lUt4ZDNgqi5BUn9BZ7YdQdI/cYlILrhdSSZJLU9aNZoD5/NBmM4SK34APB2e83MOsRt1EnkuyaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001251",
-        "colorette": "^1.3.0",
-        "electron-to-chromium": "^1.3.811",
+        "caniuse-lite": "^1.0.30001259",
+        "electron-to-chromium": "^1.3.846",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.75"
+        "nanocolors": "^0.1.5",
+        "node-releases": "^1.1.76"
       }
     },
     "buffer": {
@@ -7442,15 +7336,15 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001252",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+      "version": "1.0.30001261",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
+      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
       "dev": true
     },
     "cborg": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.5.0.tgz",
-      "integrity": "sha512-3t1+s45x5LiACi39HDiSubPZiKXU2rCreu0oi5A1nccQNDHnprCh9ZQKN1Za3eookOmL03e9oKEZ+LJs0iTE8A=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.5.1.tgz",
+      "integrity": "sha512-GKCylZR7os3Q9X+U3DiARfeFKQUdcZMAP8EKFSE91YbhJsxV71Z6PMOT2osVWprb+iWf6viyqD7peEkK0QCAAw=="
     },
     "chai": {
       "version": "4.3.4",
@@ -7542,35 +7436,18 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -7594,12 +7471,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "colorette": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
     },
     "commander": {
@@ -7660,9 +7531,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "requires": {
         "ms": "2.1.2"
       },
@@ -7837,9 +7708,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.822",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.822.tgz",
-      "integrity": "sha512-k7jG5oYYHxF4jx6PcqwHX3JVME/OjzolqOZiIogi9xtsfsmTjTdie4x88OakYFPEa8euciTgCCzvVNwvmjHb1Q==",
+      "version": "1.3.851",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.851.tgz",
+      "integrity": "sha512-Ak970eGtRSoHTaJkoDjdkeXYetbwm5Bl9pN/nPOQ3QzLfw1EWRjReOlWUra6o58SVgxfpwOT9U2P1BUXoJ57dw==",
       "dev": true
     },
     "emoji-regex": {
@@ -7879,21 +7750,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-      "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+      "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.3",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
+        "is-regex": "^1.1.4",
+        "is-string": "^1.0.7",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -8014,9 +7886,9 @@
       }
     },
     "fastq": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
-      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -8161,6 +8033,15 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "glob": {
@@ -8330,11 +8211,11 @@
       }
     },
     "idb-keyval": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.3.tgz",
-      "integrity": "sha512-N9HbCK/FaXSRVI+k6Xq4QgWxbcZRUv+SfG1y7HJ28JdV8yEJu6k+C/YLea7npGckX2DQJeEVuMc4bKOBeU/2LQ==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.5.tgz",
+      "integrity": "sha512-J1utxYWQokYjy01LvDQ7WmiAtZCGUSkVi9EIBfUSyLOr/BesnMIxNGASTh9A1LzeISSjSqEPsfFdTss7EE7ofQ==",
       "requires": {
-        "safari-14-idb-fix": "^1.0.4"
+        "safari-14-idb-fix": "^1.0.6"
       }
     },
     "ieee754": {
@@ -8375,12 +8256,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "interface-blockstore": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-1.0.1.tgz",
-      "integrity": "sha512-OYo8QXdM1UgIxftFKBgD+yM6tvHbtPu7TTgTPJS4VXY4xBwOM2sJTH8Mhe/EOGJDLXc0D0mscmlWyEhc3GSiJA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-1.0.2.tgz",
+      "integrity": "sha512-e8rHqaBSOsBPpSaB+wwVa9mR5ntU+t1yzXpOFC16cSKCNsV+h6n8SjekPQcdODVBN2h8t45CsOqRAnUfm1guEw==",
       "requires": {
         "err-code": "^3.0.1",
-        "interface-store": "^0.1.1",
+        "interface-store": "^1.0.2",
         "it-all": "^1.0.5",
         "it-drain": "^1.0.4",
         "it-filter": "^1.0.2",
@@ -8389,12 +8270,12 @@
       }
     },
     "interface-datastore": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-5.1.2.tgz",
-      "integrity": "sha512-nRFl19/IkilNzuPdCUJHejyJCZrVAk4lIRcRXJkekuTdaiagIEnCd9GfmTTQlo2afiVISk8Iy/PxSgnfmrdEIw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-5.2.0.tgz",
+      "integrity": "sha512-nthO4C4BMJM2j9x/mT2KFa/g/sbcY8yf9j/kOBgli3u5mq9ZdPvQyDxi0OhKzr4JmoM81OYh5xcFjyebquqwvA==",
       "requires": {
         "err-code": "^3.0.1",
-        "interface-store": "^0.1.1",
+        "interface-store": "^1.0.2",
         "ipfs-utils": "^8.1.2",
         "it-all": "^1.0.2",
         "it-drain": "^1.0.1",
@@ -8405,9 +8286,9 @@
       }
     },
     "interface-store": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-0.1.1.tgz",
-      "integrity": "sha512-ynnjIOybDZc0Brep3HHSa2RVlo/M5g7kuL/leui7o21EusKcLJS170vCJ8rliisc3c4jyd9ao5PthkGlBaX29g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-1.0.2.tgz",
+      "integrity": "sha512-rUBLYsgoWwxuUpnQoSUr+DR/3dH3reVeIu5aOHFZK31lAexmb++kR6ZECNRgrx6WvoaM3Akdo0A7TDrqgCzZaQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -8425,25 +8306,25 @@
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
     "ipfs-core-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.7.0.tgz",
-      "integrity": "sha512-tWJ5aJPPKeMHccPIx9EEXRZl1vsgu4rJpSPMFjjLz2JkGr6tSyCkxCOvsdSTsscfITx+NQcvcyPQb39O12fGOw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.7.3.tgz",
+      "integrity": "sha512-FkmOlqhEf3yG0K8Qt7We7kqA0xKjj8pe0dmNK593I3cgMP0MQS/xjMj1CXVdGeZc5Nn5CJ+TsuQydPbJ+7Y8eQ==",
       "requires": {
-        "interface-datastore": "^5.0.0",
+        "interface-datastore": "^5.2.0",
         "multiaddr": "^10.0.0",
         "multiformats": "^9.4.1"
       }
     },
     "ipfs-core-utils": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.10.2.tgz",
-      "integrity": "sha512-xyTqw9epOJZsa2opFp9L+7Ul/xRmWnqT8uiFW51O40jXNo95MLPgZJAOH4W5FgOR/ckpHHse+Yvqab+2YXsH3A==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.10.5.tgz",
+      "integrity": "sha512-WPRbMkbn/99pKMF3h8x1/c19+eTXVWOZu1+cmlc3NLR6gMlCd8KNpcq9OCAvs9G1JHx3w/FbEWHnqJm0TJMvrw==",
       "requires": {
         "any-signal": "^2.1.2",
         "blob-to-it": "^1.0.1",
         "browser-readablestream-to-it": "^1.0.1",
         "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.7.0",
+        "ipfs-core-types": "^0.7.3",
         "ipfs-unixfs": "^6.0.3",
         "ipfs-utils": "^8.1.4",
         "it-all": "^1.0.4",
@@ -8458,18 +8339,18 @@
       }
     },
     "ipfs-unixfs": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.5.tgz",
-      "integrity": "sha512-D8Z3EsegLxOBc2L8oMyZw/FRUDQG0ZZAaBRfzMrRsGnj7RFI7OlV1hU54aMeDxFYFviKNnUdsyEFI2zUWmgGvw==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.6.tgz",
+      "integrity": "sha512-gTkjYKXuHnqIf6EFfS+ESaYEl3I3aaQQ0UX8MhpNzreMLEuMnuqpoI/uLLllTZa31WRplKixabbpRTSmTYRNwA==",
       "requires": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.5.tgz",
-      "integrity": "sha512-H/fBcBHO4kMivj2JyqwVmp90JIxKEsRpgkyifkZxmslttcTgivrOM3s7xeLuj6EkchkqyHS9+wurdv83WFOFpQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.6.tgz",
+      "integrity": "sha512-PkKB+hTbHhKLqgj0PqSNQ/n7dKsu/lC29jLK8nUXOX4EM6c+RnedohdCY7khT10/hfC7oADbpFs/QJfuH2DaAg==",
       "requires": {
         "@ipld/dag-cbor": "^6.0.4",
         "@ipld/dag-pb": "^2.0.2",
@@ -8477,16 +8358,16 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.5",
+        "ipfs-unixfs": "^6.0.6",
         "it-last": "^1.0.5",
         "multiformats": "^9.4.2",
         "uint8arrays": "^3.0.0"
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.5.tgz",
-      "integrity": "sha512-+Xxqu7WKC/cFd/IP5bCPw4E29CybU0k/exxNJCCn/QDrSm+o25Dz4IFCLc9jXvffi9Za8gCMywZFeM2HbB5Dyg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.6.tgz",
+      "integrity": "sha512-FgzODqg4pvToEMZ88mFkHcU0s25CljmnqX2VX7K/VQDckiZIxhIiUTQRqQg/C7Em4uCzVp8YCxKUvl++w6kvNg==",
       "requires": {
         "@ipld/dag-pb": "^2.0.2",
         "@multiformats/murmur3": "^1.0.3",
@@ -8494,7 +8375,7 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.5",
+        "ipfs-unixfs": "^6.0.6",
         "it-all": "^1.0.5",
         "it-batch": "^1.0.8",
         "it-first": "^1.0.6",
@@ -8574,9 +8455,9 @@
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
     },
     "is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -8601,9 +8482,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-generator-function": {
@@ -8615,9 +8496,9 @@
       }
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.2.tgz",
+      "integrity": "sha512-ZZTOjRcDjuAAAv2cTBQP/lL59ZTArx77+7UzHdWW/XB1mrfp7DEaVpKmZ0XIzx+M7AxfhKcqV+nMetUQmFifwg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -8727,11 +8608,11 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.7.tgz",
-      "integrity": "sha512-VxlpTBGknhQ3o7YiVjIhdLU6+oD8dPz/79vvvH4F+S/c8608UCVa9fgDpa1kZgFoUST2DCgacc70UszKgzKuvA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
       "requires": {
-        "available-typed-arrays": "^1.0.4",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
@@ -8786,9 +8667,9 @@
       "integrity": "sha512-+3JqoKdBTGmyv9vOkS6b9iHhvK34UajfTibrH/1HOK8TI7K2VsM0qOCd+aJdWKtSOA8g3PqZfcwDmnR0p3klqQ=="
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.1.tgz",
+      "integrity": "sha512-GvCYYTxaCPqwMjobtVcVKvSHtAGe48MNhGjpK8LtVF8K0ISX7hCKl85LgtuaSneWVyQmaGcW3iXVV3GaZSLpmQ==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -8912,9 +8793,9 @@
       "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ=="
     },
     "it-glob": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.13.tgz",
-      "integrity": "sha512-0Hcd5BraJUPzL28NWiFbdNrcdyNxNTKKdU3sjdFiYynNTQpwlG2UKW31X7bp+XhJwux/oPzIquo5ioztVmc2RQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.14.tgz",
+      "integrity": "sha512-TKKzs9CglbsihSpcwJPXN5DBUssu4akRzPlp8QJRCoLrKoaOpyY2V1qDlxx+UMivn0i114YyTd4AawWl7eqIdw==",
       "requires": {
         "@types/minimatch": "^3.0.4",
         "minimatch": "^3.0.4"
@@ -9108,9 +8989,9 @@
       "dev": true
     },
     "map-obj": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
     "matchit": {
       "version": "1.1.0",
@@ -9221,16 +9102,16 @@
       }
     },
     "mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -9241,12 +9122,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -9254,9 +9134,9 @@
       },
       "dependencies": {
         "nanoid": {
-          "version": "3.1.23",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-          "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+          "version": "3.1.25",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+          "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
           "dev": true
         },
         "yargs-parser": {
@@ -9276,9 +9156,9 @@
       }
     },
     "mri": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
-      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "dev": true
     },
     "ms": {
@@ -9308,24 +9188,30 @@
       }
     },
     "multiformats": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.6.tgz",
-      "integrity": "sha512-ngZRO82P7mPvw/3gu5NQ2QiUJGYTS0LAxvQnEAlWCJakvn7YpK2VAd9JWM5oosYUeqoVbkylH/FsqRc4fc2+ag=="
+      "version": "9.4.8",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.8.tgz",
+      "integrity": "sha512-EOJL02/kv+FD5hoItMhKgkYUUruJYMYFq4NQ6YkCh3jVQ5CuHo+OKdHeR50hAxEQmXQ9yvrM9BxLIk42xtfwnQ=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
       "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
     },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ==",
+      "dev": true
+    },
     "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+      "version": "3.1.28",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.28.tgz",
+      "integrity": "sha512-gSu9VZ2HtmoKYe/lmyPFES5nknFrHa+/DT9muUFWFMi6Jh9E1I7bkvlQ8xxf1Kos9pi9o8lBnIOkatMhKX/YUw=="
     },
     "native-abort-controller": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
-      "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
+      "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
       "requires": {}
     },
     "native-fetch": {
@@ -9361,9 +9247,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.75",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "version": "1.1.76",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.76.tgz",
+      "integrity": "sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==",
       "dev": true
     },
     "normalize-package-data": {
@@ -9419,9 +9305,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "cliui": {
@@ -9444,12 +9330,6 @@
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
           }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
@@ -9478,24 +9358,13 @@
             "p-limit": "^2.2.0"
           }
         },
-        "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "wrap-ansi": {
@@ -9613,9 +9482,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "bl": {
@@ -9640,12 +9509,12 @@
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -10293,9 +10162,9 @@
       }
     },
     "safari-14-idb-fix": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.4.tgz",
-      "integrity": "sha512-4+Y2baQdgJpzu84d0QjySl70Kyygzf0pepVg8NVg4NnQEPpfC91fAn0baNvtStlCjUUxxiu0BOMiafa98fRRuA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
+      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA=="
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -10356,9 +10225,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
+      "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==",
       "dev": true
     },
     "sinon": {
@@ -10471,9 +10340,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -10519,28 +10388,29 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -10575,12 +10445,12 @@
       }
     },
     "strip-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.0.tgz",
-      "integrity": "sha512-UhDTSnGF1dc0DRbUqr1aXwNoY3RgVkSWG8BrpnuFIxhP57IqbS7IRta2Gfiavds4yCxc5+fEAVVOgBZWnYkvzg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^6.0.0"
+        "ansi-regex": "^6.0.1"
       }
     },
     "strip-bom": {
@@ -10938,9 +10808,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
-      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
+      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
       "dev": true
     },
     "uint8arrays": {
@@ -10996,9 +10866,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
-      "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -11091,25 +10961,16 @@
       "dev": true
     },
     "which-typed-array": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.6.tgz",
-      "integrity": "sha512-DdY984dGD5sQ7Tf+x1CkXzdg85b9uEel6nr4UkFg1LoE9OXv3uRuZhe5CoWdawhGACeFpEZXH8fFLQnDhbpm/Q==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
       "requires": {
-        "available-typed-arrays": "^1.0.4",
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
         "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.6"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
+        "is-typed-array": "^1.1.7"
       }
     },
     "workerpool": {
@@ -11130,35 +10991,18 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -11182,9 +11026,9 @@
       }
     },
     "ws": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true,
       "requires": {}
     },
@@ -11212,40 +11056,6 @@
         "string-width": "^4.2.0",
         "y18n": "^5.0.5",
         "yargs-parser": "^20.2.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        }
       }
     },
     "yargs-parser": {

--- a/src/pack/constants.ts
+++ b/src/pack/constants.ts
@@ -7,6 +7,6 @@ export const unixfsImporterOptionsDefault = {
   maxChunkSize: 262144,
   hasher: sha256,
   rawLeaves: true,
-  wrapWithDirectory: true,
+  wrapWithDirectory: false,
   maxChildrenPerNode: 174
 } as UserImporterOptions

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -28,9 +28,19 @@ export async function pack ({ input, blockstore: userBlockstore, hasher, maxChun
     throw new Error('missing input file(s)')
   }
 
-  // Disable wrap with directory if we receive byte arrays as input with no path
-  if (Array.isArray(input) && input.filter((i) => !i.path).length) {
-    wrapWithDirectory = false
+  // Transform Web File to Import candidate
+  if (Array.isArray(input) && input.filter((i) => i.name).length) {
+    input = input.map((file) => {
+      if (file.name) {
+        file.path = file.name
+      }
+      return file
+    })
+  }
+
+  // if we receive byte arrays as input with no path it must include a path or wrapWithDirectory should be disabled
+  if (Array.isArray(input) && input.filter((i) => !i.path).length && wrapWithDirectory !== false) {
+    throw new Error('inputs with no path provided need to have a path specified or wrapWithDirectory option must be disabled')
   }
 
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -28,6 +28,11 @@ export async function pack ({ input, blockstore: userBlockstore, hasher, maxChun
     throw new Error('missing input file(s)')
   }
 
+  // Disable wrap with directory if we receive byte arrays as input with no path
+  if (Array.isArray(input) && input.filter((i) => !i.path).length) {
+    wrapWithDirectory = false
+  }
+
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()
 
   // Consume the source

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -53,7 +53,7 @@ export async function pack ({ input, blockstore: userBlockstore, hasher, maxChun
       hasher: hasher || unixfsImporterOptionsDefault.hasher,
       maxChunkSize: maxChunkSize || unixfsImporterOptionsDefault.maxChunkSize,
       maxChildrenPerNode: maxChildrenPerNode || unixfsImporterOptionsDefault.maxChildrenPerNode,
-      wrapWithDirectory: wrapWithDirectory === false ? false : unixfsImporterOptionsDefault.wrapWithDirectory
+      wrapWithDirectory: wrapWithDirectory === true ? true : unixfsImporterOptionsDefault.wrapWithDirectory
     })
   ))
 

--- a/test/pack/index.browser.test.ts
+++ b/test/pack/index.browser.test.ts
@@ -23,7 +23,26 @@ describe('pack', () => {
           carParts.push(part)
         }
 
-        expect(root.toString()).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu')
+        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
+        expect(carParts.length).to.eql(4)
+      })
+
+      it('with iterable input and wrapping with directory', async () => {
+        const { root, out } = await pack({
+          input: [{
+            path: 'test.txt',
+            content: new Uint8Array([21, 31])
+          }],
+          blockstore: new Blockstore(),
+          wrapWithDirectory: true
+        })
+
+        const carParts = []
+        for await (const part of out) {
+          carParts.push(part)
+        }
+
+        expect(root.toString()).to.eql('bafybeifo5opnp65qnlowjrmrwsc6xs7tfzlehy4hsraugkaf7afzj2qkvu')
         expect(carParts.length).to.eql(7)
       })
 
@@ -40,6 +59,31 @@ describe('pack', () => {
             }
           ],
           blockstore: new Blockstore()
+        })
+
+        const carParts = []
+        for await (const part of out) {
+          carParts.push(part)
+        }
+
+        expect(root.toString()).to.eql('bafkreihdoh3xvolzxa4aa3snjjnhkgigs4rbbsj2qdax5kfbtlfewdmx5q')
+        expect(carParts.length).to.eql(7)
+      })
+
+      it('with iterable input of many files and wrapping with directory', async () => {
+        const { root, out } = await pack({
+          input: [
+            {
+              path: 'a.txt',
+              content: new Uint8Array([21, 31])
+            },
+            {
+              path: 'b.txt',
+              content: new Uint8Array([22, 32])
+            }
+          ],
+          blockstore: new Blockstore(),
+          wrapWithDirectory: true
         })
 
         const carParts = []
@@ -82,7 +126,7 @@ describe('pack', () => {
           blockstore: new Blockstore()
         })
 
-        expect(root.toString()).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu')
+        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
       })
 
       it('pack does not close provided blockstore', async () => {

--- a/test/pack/index.browser.test.ts
+++ b/test/pack/index.browser.test.ts
@@ -51,60 +51,6 @@ describe('pack', () => {
         expect(carParts.length).to.eql(10)
       })
 
-      it('can pack with an array input without path (defaults to wrapWithDirectory to false)', async () => {
-        const { root, out } = await pack({
-          input: [{
-            content: new Uint8Array([21, 31])
-          }],
-          blockstore: new Blockstore()
-        })
-
-        const carParts = []
-        for await (const part of out) {
-          carParts.push(part)
-        }
-
-        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
-        expect(carParts.length).to.eql(4)
-      })
-
-      it('can pack with an array input without path in one of the entries (defaults to wrapWithDirectory to false)', async () => {
-        const { root, out } = await pack({
-          input: [{
-              path: 'a.txt',
-              content: new Uint8Array([21, 31])
-            },
-            {
-              content: new Uint8Array([22, 32])
-            }
-          ],
-          blockstore: new Blockstore()
-        })
-
-        const carParts = []
-        for await (const part of out) {
-          carParts.push(part)
-        }
-
-        expect(root.toString()).to.eql('bafkreihdoh3xvolzxa4aa3snjjnhkgigs4rbbsj2qdax5kfbtlfewdmx5q')
-        expect(carParts.length).to.eql(7)
-      })
-
-      it('can pack with an uint8array input without path (defaults to wrapWithDirectory to false)', async () => {
-        const { root, out } = await pack({
-          input: [new Uint8Array([21, 31])],
-          blockstore: new Blockstore()
-        })
-
-        const carParts = []
-        for await (const part of out) {
-          carParts.push(part)
-        }
-
-        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
-        expect(carParts.length).to.eql(4)
-      })
-
       it('can pack with custom unixfs importer options', async () => {
         const { root, out } = await pack({
           input: [{

--- a/test/pack/index.browser.test.ts
+++ b/test/pack/index.browser.test.ts
@@ -9,7 +9,88 @@ import { MemoryBlockStore } from '../../src/blockstore/memory'
 describe('pack', () => {
   [MemoryBlockStore].map((Blockstore) => {
     describe(`with ${Blockstore.name}`, () => {
-      it('with iterable input', async () => {
+      it('with iterable input of one file', async () => {
+        const { root, out } = await pack({
+          input: [{
+            path: 'a.txt',
+            content: new Uint8Array([21, 31])
+          }],
+          blockstore: new Blockstore()
+        })
+
+        const carParts = []
+        for await (const part of out) {
+          carParts.push(part)
+        }
+
+        expect(root.toString()).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu')
+        expect(carParts.length).to.eql(7)
+      })
+
+      it('with iterable input of many files', async () => {
+        const { root, out } = await pack({
+          input: [
+            {
+              path: 'a.txt',
+              content: new Uint8Array([21, 31])
+            },
+            {
+              path: 'b.txt',
+              content: new Uint8Array([22, 32])
+            }
+          ],
+          blockstore: new Blockstore()
+        })
+
+        const carParts = []
+        for await (const part of out) {
+          carParts.push(part)
+        }
+
+        expect(root.toString()).to.eql('bafybeifvinv2j25rn2dndgrpgeo5bfrknvjpqowoxw7msr4iyub6izyr5a')
+        expect(carParts.length).to.eql(10)
+      })
+
+      it('can pack with an array input without path (defaults to wrapWithDirectory to false)', async () => {
+        const { root, out } = await pack({
+          input: [{
+            content: new Uint8Array([21, 31])
+          }],
+          blockstore: new Blockstore()
+        })
+
+        const carParts = []
+        for await (const part of out) {
+          carParts.push(part)
+        }
+
+        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
+        expect(carParts.length).to.eql(4)
+      })
+
+      it('can pack with an array input without path in one of the entries (defaults to wrapWithDirectory to false)', async () => {
+        const { root, out } = await pack({
+          input: [{
+              path: 'a.txt',
+              content: new Uint8Array([21, 31])
+            },
+            {
+              content: new Uint8Array([22, 32])
+            }
+          ],
+          blockstore: new Blockstore()
+        })
+
+        const carParts = []
+        for await (const part of out) {
+          carParts.push(part)
+        }
+
+        expect(root.toString()).to.eql('bafkreihdoh3xvolzxa4aa3snjjnhkgigs4rbbsj2qdax5kfbtlfewdmx5q')
+        expect(carParts.length).to.eql(7)
+      })
+
+      it('can pack with an uint8array input without path (defaults to wrapWithDirectory to false)', async () => {
         const { root, out } = await pack({
           input: [new Uint8Array([21, 31])],
           blockstore: new Blockstore()
@@ -20,13 +101,16 @@ describe('pack', () => {
           carParts.push(part)
         }
 
-        expect(root.toString()).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
-        expect(carParts.length).to.eql(7)
+        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
+        expect(carParts.length).to.eql(4)
       })
 
       it('can pack with custom unixfs importer options', async () => {
         const { root, out } = await pack({
-          input: [new Uint8Array([21, 31])],
+          input: [{
+            path: 'a.txt',
+            content: new Uint8Array([21, 31])
+          }],
           blockstore: new Blockstore(),
           hasher: sha512,
           maxChunkSize: 1048576,
@@ -45,11 +129,14 @@ describe('pack', () => {
 
       it('returns a car blob', async () => {
         const { root, car } = await packToBlob({
-          input: [new Uint8Array([21, 31])],
+          input: [{
+            path: 'a.txt',
+            content: new Uint8Array([21, 31])
+          }],
           blockstore: new Blockstore()
         })
 
-        expect(root.toString()).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
+        expect(root.toString()).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu')
       })
 
       it('pack does not close provided blockstore', async () => {
@@ -57,7 +144,10 @@ describe('pack', () => {
         const spy = sinon.spy(blockstore, 'close')
 
         await pack({
-          input: [new Uint8Array([21, 31])],
+          input: [{
+            path: 'a.txt',
+            content: new Uint8Array([21, 31])
+          }],
           blockstore
         })
 
@@ -70,7 +160,10 @@ describe('pack', () => {
         const spy = sinon.spy(blockstore, 'close')
 
         await packToBlob({
-          input: [new Uint8Array([21, 31])],
+          input: [{
+            path: 'a.txt',
+            content: new Uint8Array([21, 31])
+          }],
           blockstore
         })
 

--- a/test/pack/index.node.test.ts
+++ b/test/pack/index.node.test.ts
@@ -61,7 +61,7 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(3)
+        expect(files).to.have.lengthOf(2)
       })
 
       it('pack dir to car with filesystem output', async () => {
@@ -79,7 +79,7 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(3)
+        expect(files).to.have.lengthOf(2)
       })
 
       it('pack raw file to car with filesystem output', async () => {
@@ -97,7 +97,7 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(2)
+        expect(files).to.have.lengthOf(1)
 
         const rawOriginalContent = new Uint8Array(fs.readFileSync(`${__dirname}/../fixtures/file.raw`))
         const rawContent = (await all(files[files.length - 1].content()))[0]
@@ -121,7 +121,7 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(2)
+        expect(files).to.have.lengthOf(1)
 
         const rawOriginalContent = new Uint8Array(fs.readFileSync(`${__dirname}/../fixtures/file.raw`))
         const rawContent = (await all(files[files.length - 1].content()))[0]
@@ -148,7 +148,7 @@ describe('pack', () => {
         const carReader = await CarReader.fromIterable(inStream)
         const files = await all(unpack(carReader))
 
-        expect(files).to.have.lengthOf(2)
+        expect(files).to.have.lengthOf(1)
 
         const rawOriginalContent = new Uint8Array(fs.readFileSync(`${__dirname}/../fixtures/file.raw`))
         const rawContent = (await all(files[files.length - 1].content()))[0]
@@ -200,7 +200,7 @@ describe('pack', () => {
         })
 
         expect(car).to.exist
-        expect(root.toString()).to.eql('bafybeif3hyrtm2skjmldufjid3myfp37sxyqbtz7xe3f2fqyd7ugi33b2a')
+        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
         await blockstore.close()
       })
 
@@ -214,7 +214,7 @@ describe('pack', () => {
         })
 
         expect(car).to.exist
-        expect(root.toString()).to.eql('bafybeifspimntdv4o3ykr3qtt3vk5nwhegyzcktqiu2iatwuti66acbpby')
+        expect(root.toString()).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
         await blockstore.close()
       })
 

--- a/test/pack/index.node.test.ts
+++ b/test/pack/index.node.test.ts
@@ -192,12 +192,15 @@ describe('pack', () => {
         const blockstore = new Blockstore()
 
         const { car, root } = await packToBlob({
-          input: [new Uint8Array([21, 31])],
+          input: [{
+            path: 'file.txt',
+            content: new Uint8Array([21, 31])
+          }],
           blockstore
         })
 
         expect(car).to.exist
-        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
+        expect(root.toString()).to.eql('bafybeif3hyrtm2skjmldufjid3myfp37sxyqbtz7xe3f2fqyd7ugi33b2a')
         await blockstore.close()
       })
 
@@ -211,7 +214,7 @@ describe('pack', () => {
         })
 
         expect(car).to.exist
-        expect(root.toString()).to.eql('bafkreiadsbmmn4waznesyuz3bjgrj33xzqhxrk6mz3ksq7meugrachh3qe')
+        expect(root.toString()).to.eql('bafybeifspimntdv4o3ykr3qtt3vk5nwhegyzcktqiu2iatwuti66acbpby')
         await blockstore.close()
       })
 
@@ -228,6 +231,21 @@ describe('pack', () => {
           return
         }
         throw new Error('pack should throw error with empty input')
+      })
+
+      it('should error to pack byte array input with wrapWithDirectory enabled and not path', async () => {
+        const blockstore = new Blockstore()
+
+        try {
+          await pack({
+            input: [new Uint8Array([1, 2, 3])],
+            blockstore
+          })
+        } catch (err) {
+          expect(err).to.exist
+          return
+        }
+        throw new Error('pack should throw error when byte array is received as content and no path is provided')
       })
     })
   })

--- a/test/pack/index.node.test.ts
+++ b/test/pack/index.node.test.ts
@@ -197,7 +197,7 @@ describe('pack', () => {
         })
 
         expect(car).to.exist
-        expect(root.toString()).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
+        expect(root.toString()).to.eql('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby4y')
         await blockstore.close()
       })
 
@@ -211,7 +211,7 @@ describe('pack', () => {
         })
 
         expect(car).to.exist
-        expect(root.toString()).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
+        expect(root.toString()).to.eql('bafkreiadsbmmn4waznesyuz3bjgrj33xzqhxrk6mz3ksq7meugrachh3qe')
         await blockstore.close()
       })
 

--- a/test/unpack/index.browser.test.ts
+++ b/test/unpack/index.browser.test.ts
@@ -16,7 +16,8 @@ describe('unpack', () => {
         path: 'a.txt',
         content: new Uint8Array([21, 31])
       }],
-      blockstore: new MemoryBlockStore()
+      blockstore: new MemoryBlockStore(),
+      wrapWithDirectory: true
     })
 
     let bytes = new Uint8Array([])
@@ -47,7 +48,8 @@ describe('unpackStream', () => {
             path: 'a.txt',
             content: new Uint8Array([21, 31])
           }],
-          blockstore: new MemoryBlockStore()
+          blockstore: new MemoryBlockStore(),
+          wrapWithDirectory: true
         })
         const files = await all(unpackStream(out, {blockstore: new Blockstore()}))
         expect(files.length).to.eql(2)
@@ -63,7 +65,8 @@ describe('unpackStream', () => {
             path: 'a.txt',
             content: new Uint8Array([21, 31])
           }],
-          blockstore: new MemoryBlockStore()
+          blockstore: new MemoryBlockStore(),
+          wrapWithDirectory: true
         })
         const stream = new ReadableStream({
           async pull(controller) {

--- a/test/unpack/index.browser.test.ts
+++ b/test/unpack/index.browser.test.ts
@@ -12,21 +12,29 @@ import { IdbBlockStore } from '../../src/blockstore/idb'
 describe('unpack', () => {
   it('with CarReader input', async () => {
     const { out } = await pack({
-      input: [new Uint8Array([21, 31])],
+      input: [{
+        path: 'a.txt',
+        content: new Uint8Array([21, 31])
+      }],
       blockstore: new MemoryBlockStore()
     })
 
     let bytes = new Uint8Array([])
+    let carParts = []
     for await (const part of out) {
+      carParts.push(part)
       bytes = concat([bytes, new Uint8Array(part)])
     }
 
     const carReader = await CarReader.fromBytes(bytes)
     const files = await all(unpack(carReader))
 
-    expect(files.length).to.eql(1)
+    expect(files.length).to.eql(2)
     expect(files[0].type).to.eql('directory')
-    expect(files[0].name).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
+    expect(files[0].name).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu')
+    expect(files[1].type).to.eql('raw')
+    expect(files[1].name).to.eql('a.txt')
+    expect(files[1].path).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu/a.txt')
   })
 })
 
@@ -35,17 +43,26 @@ describe('unpackStream', () => {
     describe(`with ${Blockstore.name}`, () => {
       it('with iterable input', async () => {
         const { out } = await pack({
-          input: [new Uint8Array([21, 31])],
+          input: [{
+            path: 'a.txt',
+            content: new Uint8Array([21, 31])
+          }],
           blockstore: new MemoryBlockStore()
         })
         const files = await all(unpackStream(out, {blockstore: new Blockstore()}))
-        expect(files.length).to.eql(1)
+        expect(files.length).to.eql(2)
         expect(files[0].type).to.eql('directory')
-        expect(files[0].name).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
+        expect(files[0].name).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu')
+        expect(files[1].type).to.eql('raw')
+        expect(files[1].name).to.eql('a.txt')
+        expect(files[1].path).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu/a.txt')
       })
       it('with readablestream input', async () => {
         const { out } = await pack({
-          input: [new Uint8Array([21, 31])],
+          input: [{
+            path: 'a.txt',
+            content: new Uint8Array([21, 31])
+          }],
           blockstore: new MemoryBlockStore()
         })
         const stream = new ReadableStream({
@@ -57,9 +74,12 @@ describe('unpackStream', () => {
           }
         })
         const files = await all(unpackStream(stream, {blockstore: new Blockstore()}))
-        expect(files.length).to.eql(1)
+        expect(files.length).to.eql(2)
         expect(files[0].type).to.eql('directory')
-        expect(files[0].name).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
+        expect(files[0].name).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu')
+        expect(files[1].type).to.eql('raw')
+        expect(files[1].name).to.eql('a.txt')
+        expect(files[1].path).to.eql('bafybeiglo54z2343qksf253l2xtsik3n4kdguwtfayhhtn36btqrnlwrsu/a.txt')
       })
     })
   })


### PR DESCRIPTION
BREAKING CHANGE: do not wrap array inputs without path may result in different CIDs generated

On pack, unixfs importer will yield the added data + empty dir in the end.  Which means that the CarWriter will receive all the blocks and the car file is well written, but the root CID will be the empty Dir.

So, what is the issue? When we pack, if we provide an ImportCandidate as new `Uint8Array([1, 2, 3])` there will be no path to create DAG Links, which means it will write both the file block and the wrapping directory block into the writer, but as it cannot infer any relationship, it will be an empty directory. However, If I provide an importCandidate as `{ path: 'a.txt', content: new Uint8array([1, 2, 3] }` , then we will actually get a non empty directory.

Given we provide a path (aka name) in web3.storage client, this is not a problem in web3.storage, nor in Node.js where we get the fs paths. I wonder if we should just make ipfs-car pack to not accept simple uint8array as input, despite they being perfectly valid if we do not use wrapWithDirectory . unixfs-import should probably handle this, but I don’t know if there is a reason behind the decision