### PR TITLE
feat: implement has

### DIFF
--- a/src/blockstore/fs.ts
+++ b/src/blockstore/fs.ts
@@ -48,6 +48,21 @@ export class FsBlockStore extends BlockstoreAdapter implements Blockstore {
     return bytes
   }
 
+  async has (cid: CID) {
+    if (!this._opened) {
+      await this._open()
+    }
+
+    const cidStr = cid.toString()
+    const location = `${this.path}/${cidStr}`
+    try {
+      await fs.promises.access(location)
+      return true
+    } catch (err) {
+      return false
+    }
+  }
+
   async * blocks () {
     if (!this._opened) {
       await this._open()

--- a/src/blockstore/idb.ts
+++ b/src/blockstore/idb.ts
@@ -44,6 +44,11 @@ export class IdbBlockStore extends BlockstoreAdapter implements Blockstore {
     return bytes
   }
 
+  async has (cid: CID) {
+    const bytes = await idb.get(cid.toString(), this.store)
+    return Boolean(bytes)
+  }
+
   async close () {
     return idb.clear(this.store)
   }

--- a/src/blockstore/memory.ts
+++ b/src/blockstore/memory.ts
@@ -32,6 +32,10 @@ export class MemoryBlockStore extends BlockstoreAdapter implements Blockstore {
     return Promise.resolve(bytes)
   }
 
+  has (cid: CID) {
+    return Promise.resolve(this.store.has(cid.toString()))
+  }
+
   close () {
     this.store.clear()
     return Promise.resolve()

--- a/test/blockstore/index.browser.test.ts
+++ b/test/blockstore/index.browser.test.ts
@@ -52,6 +52,13 @@ describe('blockstore', () => {
         const blocks = await all(blockstore.blocks())
         expect(blocks.length).eql(3)
       })
+
+      it('can has', async () => {
+        await blockstore.put(cid, bytes)
+        expect(await blockstore.has(cid)).to.eql(true)
+        const externalCid = CID.parse('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby5y')
+        expect(await blockstore.has(externalCid)).to.eql(false)
+      })
     })
   })
 })

--- a/test/blockstore/index.node.test.ts
+++ b/test/blockstore/index.node.test.ts
@@ -56,6 +56,13 @@ describe('blockstore', () => {
       it('can close immediately after creating', () => {
         // Do nothing, rely on beforeEach and afterEach
       })
+
+      it('can has', async () => {
+        await blockstore.put(cid, bytes)
+        expect(await blockstore.has(cid)).to.eql(true)
+        const externalCid = CID.parse('bafkreifidl2jnal7ycittjrnbki6jasdxwwvpf7fj733vnyhidtusxby5y')
+        expect(await blockstore.has(externalCid)).to.eql(false)
+      })
     })
   })
 })


### PR DESCRIPTION
I'm implementing a blockstore backed CAR reader over here https://github.com/ipfs-shipyard/nft.storage/pull/588/files#diff-14c5d808d5ff6c8140013ca1bb6c6824c82b2dfdf928d4fe2e8fe8336453559f and the `CarReader` interface needs a `has` method implemented in the blockstore.

We can potentially use this here https://github.com/web3-storage/web3.storage/blob/main/packages/client/src/lib.js#L116 to avoid reading the entire CAR into memory after we've packed it into a blockstore.