### PR TITLE
Give CLI users the option to wrap or NOT wrap with directory

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -14,6 +14,7 @@ interface Flags {
   list?: string,
   listCids?: string
   listRoots?: string
+  wrapWithDirectory?: boolean
 }
 
 const options = {
@@ -43,6 +44,11 @@ const options = {
     },
     listRoots: {
       type: 'string'
+    },
+    wrapWithDirectory: {
+      type: 'boolean',
+      alias: 'w',
+      default: true
     }
   }
 } as const;
@@ -62,6 +68,9 @@ const cli = meow(`
 
     # specify the car file name.
     $ ipfs-car --pack path/to/files --output path/to/write/a.car
+
+    # pack files without wrapping with top-level directory
+    $ ipfs-car --wrapWithDirectory false --pack path/to/files --output path/to/write/a.car
 
   Unpacking files from a .car
 
@@ -96,7 +105,7 @@ const cli = meow(`
 
 async function handleInput ({ flags }: { flags: Flags }) {
   if (flags.pack) {
-    const { root, filename } = await packToFs({input: flags.pack, output: flags.output})
+    const { root, filename } = await packToFs({input: flags.pack, output: flags.output, wrapWithDirectory: flags.wrapWithDirectory})
     // tslint:disable-next-line: no-console
     console.log(`root CID: ${root.toString()}`)
     // tslint:disable-next-line: no-console


### PR DESCRIPTION
It seems that there is some controversy on this subject (#57, #88, #89) -- I'm not sure on the finer points discussed, but in practice I need to emit a root CID without wrapping to match how my other DAGs are processed in estuary. The files come from a system that does not rely on fs level metadata (Internet Archive, file metadata is stored separately in an xml system) so I don't need the wrapper. I think threading this through gives users the flexibility to get the behavior they need.

```
$ ./dist/cjs/cli/cli.js --pack ../derive-car/test/item/ --output /tmp/item.car
root CID: bafybeidmfmezmxnhnx4pnolbqriolgivs3xqcecsw7lbaiytjwqb4hidr4
  output: /tmp/item.car
$ ipfs-car --list /tmp/item.car 
bafybeidmfmezmxnhnx4pnolbqriolgivs3xqcecsw7lbaiytjwqb4hidr4
bafybeidmfmezmxnhnx4pnolbqriolgivs3xqcecsw7lbaiytjwqb4hidr4/item
...
$ ./dist/cjs/cli/cli.js --wrapWithDirectory false --pack ../derive-car/test/item/ --output /tmp/item.car
root CID: bafybeiar5v44pavnjsnz3tzmgnamrl36sioeakcbndw3t52dvg3crwnogy
  output: /tmp/item.car
$ ipfs-car --list /tmp/item.car 
bafybeiar5v44pavnjsnz3tzmgnamrl36sioeakcbndw3t52dvg3crwnogy
...
```

The root CID in the second case matches my other tools' output.