### PR TITLE
test: make rm temporary files tolerant to errors in windows

### DIFF
--- a/test/pack/index.node.test.ts
+++ b/test/pack/index.node.test.ts
@@ -29,7 +29,11 @@ describe('pack', () => {
       })
 
       afterEach(() => {
-        fs.rmSync(dirTmp, { recursive: true })
+        try {
+          fs.rmSync(dirTmp, { recursive: true })
+        } catch (e) {
+          // Windows Workers in CI _sometimes_ fail with permissions
+        }
       })
 
       it('can pack from a readable stream', async () => {
@@ -129,7 +133,11 @@ describe('pack', () => {
         expect(equals(rawOriginalContent, rawContent)).to.eql(true)
 
         // Remove created file
-        fs.rmSync(newCarPath)
+        try {
+          fs.rmSync(newCarPath)
+        } catch (e) {
+          // Windows Workers in CI _sometimes_ fail with permissions
+        }
       })
 
       it('pack raw file to car with writable stream', async () => {

--- a/test/unpack/index.node.test.ts
+++ b/test/unpack/index.node.test.ts
@@ -54,7 +54,11 @@ describe('unpackStreamToFs', () => {
   })
 
   afterEach(() => {
-    fs.rmSync(dirTmp, { recursive: true })
+    try {
+      fs.rmSync(dirTmp, { recursive: true })
+    } catch (e) {
+      // Windows Workers in CI _sometimes_ fail with permissions
+    }
   })
 
   it('raw file stream', async () => {
@@ -90,7 +94,11 @@ describe('unpackToFs', () => {
   })
 
   afterEach(() => {
-    fs.rmSync(dirTmp, { recursive: true })
+    try {
+      fs.rmSync(dirTmp, { recursive: true })
+    } catch (e) {
+      // Windows Workers in CI _sometimes_ fail with permissions
+    }
   })
 
   it('file system raw', async () => {


### PR DESCRIPTION
Tests are flaky by removing tmp files from disk. This only happens in some windows machines in github actions that likely do not have permissions in the tmp folder. This can just be ignored and move forward as this does not represent any problem with the actual code.

Closes #106 