### PR TITLE
chore: update @ipld/car and multiformats deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.1",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@ipld/car": "^3.1.4",
+        "@ipld/car": "^3.2.3",
         "@web-std/blob": "^3.0.1",
         "bl": "^5.0.0",
         "blockstore-core": "^1.0.2",
@@ -26,7 +26,7 @@
         "it-pipe": "^1.1.0",
         "meow": "^9.0.0",
         "move-file": "^2.1.0",
-        "multiformats": "^9.3.0",
+        "multiformats": "^9.6.3",
         "stream-to-it": "^0.2.3",
         "streaming-iterables": "^6.0.0",
         "uint8arrays": "^3.0.0"
@@ -490,14 +490,22 @@
       }
     },
     "node_modules/@ipld/car": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.19.tgz",
-      "integrity": "sha512-uHQYA9f/WV2xTNITZf451kgFM66JGZW0xMRn/ckkSlHPFpAqta2QSuViQ8ElnnCeMAm340/byCbzxYfPv4kycg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.2.3.tgz",
+      "integrity": "sha512-pXE5mFJlXzJVaBwqAJKGlKqMmxq8H2SLEWBJgkeBDPBIN8ZbscPc3I9itkSQSlS/s6Fgx35Ri3LDTDtodQjCCQ==",
       "dependencies": {
-        "@ipld/dag-cbor": "^6.0.0",
-        "@types/varint": "^6.0.0",
-        "multiformats": "^9.0.0",
+        "@ipld/dag-cbor": "^7.0.0",
+        "multiformats": "^9.5.4",
         "varint": "^6.0.0"
+      }
+    },
+    "node_modules/@ipld/car/node_modules/@ipld/dag-cbor": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.0.tgz",
+      "integrity": "sha512-us/dagGvfQ+acO8uyAfozUQ21xxvI6ZrCWwfbOuk+o+cSpCIKY30lUYRuN3kzWLvTJHvbuCVPVEH38ynM1ZBgw==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^9.5.4"
       }
     },
     "node_modules/@ipld/dag-cbor": {
@@ -849,14 +857,6 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/fake-timers": "^7.1.0"
-      }
-    },
-    "node_modules/@types/varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/yauzl": {
@@ -1333,9 +1333,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.5.2.tgz",
-      "integrity": "sha512-w7RJ0Hm29B/Y5kvUXrP+TfgvBmkRUwYVr8hD63z5MlIGdlelhzNMCV/xKbG+yAyp4euJrqxPsQMXGyJKnfGhPQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.6.1.tgz",
+      "integrity": "sha512-dOGlTG610S6t3j7EYFxPBH7KiF1OlSAdWtMI4Iv1dabcId/L/nUvkfOEPge+vDp9YoPerEMiDoy5+Vm2oEqmQw==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -4170,9 +4170,9 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "9.4.8",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.8.tgz",
-      "integrity": "sha512-EOJL02/kv+FD5hoItMhKgkYUUruJYMYFq4NQ6YkCh3jVQ5CuHo+OKdHeR50hAxEQmXQ9yvrM9BxLIk42xtfwnQ=="
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.3.tgz",
+      "integrity": "sha512-yfXKI66fL0nFzt0nJl26i4wV1qAqbAEIBvfFbkbsne9GrLz6IHvHUoRyxUtlJcdP181ssOgjama6E/VSk4pbrA=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -7172,14 +7172,24 @@
       }
     },
     "@ipld/car": {
-      "version": "3.1.19",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.19.tgz",
-      "integrity": "sha512-uHQYA9f/WV2xTNITZf451kgFM66JGZW0xMRn/ckkSlHPFpAqta2QSuViQ8ElnnCeMAm340/byCbzxYfPv4kycg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.2.3.tgz",
+      "integrity": "sha512-pXE5mFJlXzJVaBwqAJKGlKqMmxq8H2SLEWBJgkeBDPBIN8ZbscPc3I9itkSQSlS/s6Fgx35Ri3LDTDtodQjCCQ==",
       "requires": {
-        "@ipld/dag-cbor": "^6.0.0",
-        "@types/varint": "^6.0.0",
-        "multiformats": "^9.0.0",
+        "@ipld/dag-cbor": "^7.0.0",
+        "multiformats": "^9.5.4",
         "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "@ipld/dag-cbor": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-7.0.0.tgz",
+          "integrity": "sha512-us/dagGvfQ+acO8uyAfozUQ21xxvI6ZrCWwfbOuk+o+cSpCIKY30lUYRuN3kzWLvTJHvbuCVPVEH38ynM1ZBgw==",
+          "requires": {
+            "cborg": "^1.6.0",
+            "multiformats": "^9.5.4"
+          }
+        }
       }
     },
     "@ipld/dag-cbor": {
@@ -7500,14 +7510,6 @@
       "dev": true,
       "requires": {
         "@sinonjs/fake-timers": "^7.1.0"
-      }
-    },
-    "@types/varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==",
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/yauzl": {
@@ -7858,9 +7860,9 @@
       "dev": true
     },
     "cborg": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.5.2.tgz",
-      "integrity": "sha512-w7RJ0Hm29B/Y5kvUXrP+TfgvBmkRUwYVr8hD63z5MlIGdlelhzNMCV/xKbG+yAyp4euJrqxPsQMXGyJKnfGhPQ=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.6.1.tgz",
+      "integrity": "sha512-dOGlTG610S6t3j7EYFxPBH7KiF1OlSAdWtMI4Iv1dabcId/L/nUvkfOEPge+vDp9YoPerEMiDoy5+Vm2oEqmQw=="
     },
     "chai": {
       "version": "4.3.4",
@@ -9953,9 +9955,9 @@
       }
     },
     "multiformats": {
-      "version": "9.4.8",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.8.tgz",
-      "integrity": "sha512-EOJL02/kv+FD5hoItMhKgkYUUruJYMYFq4NQ6YkCh3jVQ5CuHo+OKdHeR50hAxEQmXQ9yvrM9BxLIk42xtfwnQ=="
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.3.tgz",
+      "integrity": "sha512-yfXKI66fL0nFzt0nJl26i4wV1qAqbAEIBvfFbkbsne9GrLz6IHvHUoRyxUtlJcdP181ssOgjama6E/VSk4pbrA=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "homepage": "https://github.com/web3-storage/ipfs-car#readme",
   "dependencies": {
-    "@ipld/car": "^3.1.4",
+    "@ipld/car": "^3.2.3",
     "@web-std/blob": "^3.0.1",
     "bl": "^5.0.0",
     "blockstore-core": "^1.0.2",
@@ -140,7 +140,7 @@
     "it-pipe": "^1.1.0",
     "meow": "^9.0.0",
     "move-file": "^2.1.0",
-    "multiformats": "^9.3.0",
+    "multiformats": "^9.6.3",
     "stream-to-it": "^0.2.3",
     "streaming-iterables": "^6.0.0",
     "uint8arrays": "^3.0.0"


### PR DESCRIPTION
This updates `multiformats` to `^9.6.3` and `@ipld/car` to `^3.2.3` (both the current latest versions).

This seems to fix the error I'm seeing in metaplex when importing the `nft.storage` client:

```
yarn run v1.22.17
$ tsc -p ./src
../../node_modules/ipfs-car/dist/types/blockstore/memory.d.ts:7:5 - error TS2416: Property 'blocks' in type 'MemoryBlockStore' is not assignable to the same property in base type 'Blockstore'.
  Type '() => AsyncGenerator<{ cid: CID; bytes: Uint8Array; }, void, unknown>' is not assignable to type '() => AsyncGenerator<Block, void, unknown>'.
    Call signature return types 'AsyncGenerator<{ cid: CID; bytes: Uint8Array; }, void, unknown>' and 'AsyncGenerator<Block, void, unknown>' are incompatible.
      The types returned by 'next(...)' are incompatible between these types.
        Type 'Promise<IteratorResult<{ cid: CID; bytes: Uint8Array; }, void>>' is not assignable to type 'Promise<IteratorResult<Block, void>>'.
          Type 'IteratorResult<{ cid: CID; bytes: Uint8Array; }, void>' is not assignable to type 'IteratorResult<Block, void>'.
            Type 'IteratorYieldResult<{ cid: CID; bytes: Uint8Array; }>' is not assignable to type 'IteratorResult<Block, void>'.
              Type 'IteratorYieldResult<{ cid: CID; bytes: Uint8Array; }>' is not assignable to type 'IteratorYieldResult<Block>'.
                Type '{ cid: CID; bytes: Uint8Array; }' is not assignable to type 'Block'.

7     blocks(): AsyncGenerator<{
      ~~~~~~
```

Which AFAICT is caused by two incompatible versions of `multiformats/cid` being pulled in by various packages.

If I `yarn link` this PR branch into the metaplex project I'm trying to build, the errors go away, so hopefully this is the root cause :)