### PR TITLE
feat!: iana media type application/vnd.ipld.car

### DIFF
--- a/src/pack/blob.ts
+++ b/src/pack/blob.ts
@@ -27,7 +27,8 @@ export async function packToBlob ({ input, blockstore: userBlockstore, hasher, m
   }
 
   const car = new Blob(carParts, {
-    type: 'application/car',
+    // https://www.iana.org/assignments/media-types/application/vnd.ipld.car
+    type: 'application/vnd.ipld.car',
   })
 
   return { root, car }

--- a/test/pack/index.browser.test.ts
+++ b/test/pack/index.browser.test.ts
@@ -50,6 +50,7 @@ describe('pack', () => {
         })
 
         expect(root.toString()).to.eql('bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354')
+        expect(car.type).to.eql('application/vnd.ipld.car')
       })
 
       it('pack does not close provided blockstore', async () => {


### PR DESCRIPTION
We now have an official IANA media type for CARs `application/vnd.ipld.car` so use it here.

see: https://github.com/web3-storage/web3.storage/issues/1206
see: https://www.iana.org/assignments/media-types/application/vnd.ipld.car

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>