### PR TITLE
Handle kill signal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "uint8arrays": "^3.0.0"
       },
       "bin": {
-        "🚘": "dist/cjs/cli/cli.js",
         "ipfs-car": "dist/cjs/cli/cli.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "/dist"
   ],
   "bin": {
-    "🚘": "./dist/cjs/cli/cli.js",
     "ipfs-car": "./dist/cjs/cli/cli.js"
   },
   "repository": {

--- a/src/blockstore/fs.ts
+++ b/src/blockstore/fs.ts
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import os from 'os'
 
 import { CID } from 'multiformats'
 import { BaseBlockstore } from 'blockstore-core'
@@ -10,9 +9,9 @@ export class FsBlockStore extends BaseBlockstore implements Blockstore {
   _opened: boolean
   _opening?: Promise<void>
 
-  constructor () {
+  constructor (path: string) {
     super()
-    this.path = `${os.tmpdir()}/${(parseInt(String(Math.random() * 1e9), 10)).toString() + Date.now()}`
+    this.path = path
     this._opened = false
   }
 

--- a/src/unpack/fs.ts
+++ b/src/unpack/fs.ts
@@ -12,7 +12,7 @@ import { FsBlockStore } from '../blockstore/fs'
 import toIterable from 'stream-to-it'
 
 import { unpack, unpackStream } from './index'
-import { Blockstore } from '../blockstore/index'
+import { Blockstore } from '../blockstore'
 
 // Node only, read a car from fs, write files to fs
 export async function unpackToFs ({input, roots, output}: {input: string, roots?: CID[], output?: string}) {
@@ -22,7 +22,7 @@ export async function unpackToFs ({input, roots, output}: {input: string, roots?
 
 // Node only, read a stream, write files to fs
 export async function unpackStreamToFs ({input, roots, output, blockstore: userBlockstore}: {input: AsyncIterable<Uint8Array>, roots?: CID[], output?: string, blockstore?: Blockstore}) {
-  const blockstore = userBlockstore ? userBlockstore : new FsBlockStore()
+  const blockstore = userBlockstore ? userBlockstore : new FsBlockStore(output ? output : (roots ? roots[0].toString() : "output"))
   await writeFiles(unpackStream(input, { roots, blockstore }), output)
   if (!userBlockstore) {
     await blockstore.close()


### PR DESCRIPTION
The temporary car file has been moved to the directory containing the folder or file being packed into the car.
This allows to not have to do multiple copies off of multiple drives (when the tmp folder may be on another drive).
The temporary file and folder have been renamed to make sense and allow people to see if the file is there and the name should make sense compared to the final one.

At the same time, now the kill signal is being handled and on kill, these are being deleted.