### PR TITLE
Display cids with associated filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IDE files
+.idea/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ $ ipfs-car --pack path/to/files --output path/to/write/a.car
 # use --wrapWithDirectory false to avoid this.
 $ ipfs-car --pack path/to/file --wrapWithDirectory false --output path/to/write/a.car
 
+# displays which file is being packed
+$ ipfs-car --pack path/to/files --verbose
 ```
 
 `--unpack` files from a .car
@@ -83,6 +85,9 @@ $ ipfs-car --list-roots path/to/my.car
 
 # list the cids for all the blocks.
 $ ipfs-car --list-cids path/to/my.car
+
+# list both the files and their CIDs.
+$ ipfs-car --list-full path/to/my.car
 ```
 
 ## API
@@ -103,7 +108,7 @@ To unpack content-addressable archives to files, you can use the functions provi
 
 ### `ipfs-car/pack`
 
-Takes an [ImportCandidateStream](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-core-types/src/utils.ts#L21) and returns a a [CAR writer](https://github.com/ipld/js-car#carwriter) async iterable.
+Takes an [ImportCandidateStream](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-core-types/src/utils.ts#L21) and returns a [CAR writer](https://github.com/ipld/js-car#carwriter) async iterable.
 
 ```js
 import { pack } from 'ipfs-car/pack'
@@ -112,7 +117,7 @@ import { MemoryBlockStore } from 'ipfs-car/blockstore/memory' // You can also us
 const { root, out } = await pack({
   input: [new Uint8Array([21, 31, 41])],
   blockstore: new MemoryBlockStore(),
-  wrapWithDirectory: true // Wraps input into a directory. Defaults to `true`
+  wrapWithDirectory: true, // Wraps input into a directory. Defaults to `true`
   maxChunkSize: 262144 // The maximum block size in bytes. Defaults to `262144`. Max safe value is < 1048576 (1MiB)
 })
 
@@ -205,7 +210,7 @@ for await (const file of unpackStream(inStream)) {
 `unpackStream` takes an options object, allowing you to pass in a `BlockStore` implementation. The blocks are unpacked from the stream in the order they appear, which may not be the order needed to reassemble them into the Files and Directories they represent. The blockstore is used to store the blocks as they are consumed from the stream. Once the stream is consumed, the blockstore provides the random access by CID to the blocks, needed to assemble the tree.
 
 The default is a [`MemoryBlockStore`](./src/blockstore/memory.ts), that will store all the blocks in memory.
-For larger CARs in the browser you can use IndexedDB by passing in an [IdbBlocksStore]('./src/blockstore/idb.ts'), and in Node.js you can provide a [FsBlockStore] instance to write blocks to the tmp dir.
+For larger CARs in the browser you can use IndexedDB by passing in an [IdbBlocksStore](./src/blockstore/idb.ts), and in Node.js you can provide an [FsBlockStore] instance to write blocks to the tmp dir.
 
 ```js
 /* browser */
@@ -224,7 +229,7 @@ for await (const file of unpackStream(res.body, { blockstore })) {
 blockstore.destroy()
 ```
 
-When providing a custom Blockstore, it is your responsibiltiy to call `blockstore.destroy()` when you're finished. Failing to do so will fill up the users storage.
+When providing a custom Blockstore, it is your responsibility to call `blockstore.destroy()` when you're finished. Failing to do so will fill up the users' storage.
 
 ### `ipfs-car/unpack/fs`
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -16,6 +16,7 @@ interface Flags {
   listRoots?: string
   listFull?: string
   wrapWithDirectory?: boolean
+  verbose?: boolean
 }
 
 const options = {
@@ -53,6 +54,11 @@ const options = {
       type: 'boolean',
       alias: 'w',
       default: true
+    },
+    verbose: {
+      type: 'boolean',
+      alias: 'v',
+      default: false
     }
   }
 } as const;
@@ -75,6 +81,9 @@ const cli = meow(`
 
     # pack files without wrapping with top-level directory
     $ ipfs-car --wrapWithDirectory false --pack path/to/files --output path/to/write/a.car
+
+    # pack files and display which one is being packed
+    $ ipfs-car --pack /path/to/files --verbose
 
   Unpacking files from a .car
 
@@ -112,7 +121,7 @@ const cli = meow(`
 
 async function handleInput ({ flags }: { flags: Flags }) {
   if (flags.pack) {
-    const { root, filename } = await packToFs({input: flags.pack, output: flags.output, wrapWithDirectory: flags.wrapWithDirectory})
+    const { root, filename } = await packToFs({input: flags.pack, output: flags.output, wrapWithDirectory: flags.wrapWithDirectory, verbose: flags.verbose})
     // tslint:disable-next-line: no-console
     console.log(`root CID: ${root.toString()}`)
     // tslint:disable-next-line: no-console

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -5,6 +5,7 @@ import { CID } from 'multiformats';
 import { packToFs } from '../pack/fs'
 import { unpackToFs, unpackStreamToFs } from '../unpack/fs'
 import {listFilesInCar, listCidsInCar, listRootsInCar, listFilesAndCidsInCar} from './lib'
+import {printUnixFsContent} from "./verbose-handler";
 
 interface Flags {
   output?: string,
@@ -121,7 +122,7 @@ const cli = meow(`
 
 async function handleInput ({ flags }: { flags: Flags }) {
   if (flags.pack) {
-    const { root, filename } = await packToFs({input: flags.pack, output: flags.output, wrapWithDirectory: flags.wrapWithDirectory, verbose: flags.verbose})
+    const { root, filename } = await packToFs({input: flags.pack, output: flags.output, wrapWithDirectory: flags.wrapWithDirectory, customHandler: flags.verbose ? printUnixFsContent : undefined})
     // tslint:disable-next-line: no-console
     console.log(`root CID: ${root.toString()}`)
     // tslint:disable-next-line: no-console

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -4,7 +4,7 @@ import meow from 'meow'
 import { CID } from 'multiformats';
 import { packToFs } from '../pack/fs'
 import { unpackToFs, unpackStreamToFs } from '../unpack/fs'
-import { listFilesInCar, listCidsInCar, listRootsInCar } from './lib'
+import {listFilesInCar, listCidsInCar, listRootsInCar, listFilesAndCidsInCar} from './lib'
 
 interface Flags {
   output?: string,
@@ -14,6 +14,7 @@ interface Flags {
   list?: string,
   listCids?: string
   listRoots?: string
+  listFull?: string
   wrapWithDirectory?: boolean
 }
 
@@ -43,6 +44,9 @@ const options = {
       type: 'string'
     },
     listRoots: {
+      type: 'string'
+    },
+    listFull: {
       type: 'string'
     },
     wrapWithDirectory: {
@@ -97,6 +101,9 @@ const cli = meow(`
     # list the files.
     $ ipfs-car --list path/to/my.car
 
+    # list both the files' path and their CIDs.
+    $ ipfs-car --list-full path/to/my.car
+
   TL;DR
   --pack <path> --output <my.car>
   --unpack <my.car> --output <path>
@@ -126,6 +133,9 @@ async function handleInput ({ flags }: { flags: Flags }) {
 
   } else if (flags.listCids) {
     return listCidsInCar({input: flags.listCids})
+
+  } else if (flags.listFull) {
+    return listFilesAndCidsInCar({input: flags.listFull})
 
   } else if (!process.stdin.isTTY) {
     // maybe stream?

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -122,7 +122,7 @@ const cli = meow(`
 
 async function handleInput ({ flags }: { flags: Flags }) {
   if (flags.pack) {
-    const { root, filename } = await packToFs({input: flags.pack, output: flags.output, wrapWithDirectory: flags.wrapWithDirectory, customHandler: flags.verbose ? printUnixFsContent : undefined})
+    const { root, filename } = await packToFs({input: flags.pack, output: flags.output, wrapWithDirectory: flags.wrapWithDirectory, customStreamSink: flags.verbose ? printUnixFsContent : undefined})
     // tslint:disable-next-line: no-console
     console.log(`root CID: ${root.toString()}`)
     // tslint:disable-next-line: no-console

--- a/src/cli/lib.ts
+++ b/src/cli/lib.ts
@@ -26,3 +26,11 @@ export async function listRootsInCar ({input}: {input: string}) {
     console.log(root.toString())
   }
 }
+
+export async function listFilesAndCidsInCar({input}: {input: string}) {
+  const carReader = await CarIndexedReader.fromFile(input)
+  for await (const file of unpack(carReader)) {
+    // tslint:disable-next-line: no-console
+    console.log(`${file.cid.toString()} ${file.path}`)
+  }
+}

--- a/src/cli/verbose-handler.ts
+++ b/src/cli/verbose-handler.ts
@@ -1,0 +1,9 @@
+import {ImportResult} from "ipfs-unixfs-importer";
+
+export async function *printUnixFsContent(root: AsyncGenerator<ImportResult, void, unknown>): AsyncGenerator<ImportResult, void, unknown> {
+  for await (const entry of root) {
+    // tslint:disable-next-line:no-console
+    console.log(`${entry.cid.toString()} ${entry.path}`)
+    yield entry
+  }
+}

--- a/src/pack/fs.ts
+++ b/src/pack/fs.ts
@@ -12,7 +12,7 @@ export interface PackToFsProperties extends PackProperties {
   output?: string
 }
 
-export async function packToFs ({ input, output, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves }: PackToFsProperties) {
+export async function packToFs ({ input, output, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, verbose }: PackToFsProperties) {
   const blockstore = userBlockstore ? userBlockstore : new FsBlockStore()
   const location = output || `${os.tmpdir()}/${(parseInt(String(Math.random() * 1e9), 10)).toString() + Date.now()}`
   const writable = fs.createWriteStream(location)
@@ -25,7 +25,8 @@ export async function packToFs ({ input, output, blockstore: userBlockstore, has
     maxChunkSize,
     maxChildrenPerNode,
     wrapWithDirectory,
-    rawLeaves
+    rawLeaves,
+    verbose
   })
 
   if (!userBlockstore) {

--- a/src/pack/fs.ts
+++ b/src/pack/fs.ts
@@ -12,7 +12,7 @@ export interface PackToFsProperties extends PackProperties {
   output?: string
 }
 
-export async function packToFs ({ input, output, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, customHandler }: PackToFsProperties) {
+export async function packToFs ({ input, output, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, customStreamSink }: PackToFsProperties) {
   const blockstore = userBlockstore ? userBlockstore : new FsBlockStore()
   const location = output || `${os.tmpdir()}/${(parseInt(String(Math.random() * 1e9), 10)).toString() + Date.now()}`
   const writable = fs.createWriteStream(location)
@@ -26,7 +26,7 @@ export async function packToFs ({ input, output, blockstore: userBlockstore, has
     maxChildrenPerNode,
     wrapWithDirectory,
     rawLeaves,
-    customHandler
+    customStreamSink
   })
 
   if (!userBlockstore) {

--- a/src/pack/fs.ts
+++ b/src/pack/fs.ts
@@ -12,7 +12,7 @@ export interface PackToFsProperties extends PackProperties {
   output?: string
 }
 
-export async function packToFs ({ input, output, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, verbose }: PackToFsProperties) {
+export async function packToFs ({ input, output, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, customHandler }: PackToFsProperties) {
   const blockstore = userBlockstore ? userBlockstore : new FsBlockStore()
   const location = output || `${os.tmpdir()}/${(parseInt(String(Math.random() * 1e9), 10)).toString() + Date.now()}`
   const writable = fs.createWriteStream(location)
@@ -26,7 +26,7 @@ export async function packToFs ({ input, output, blockstore: userBlockstore, has
     maxChildrenPerNode,
     wrapWithDirectory,
     rawLeaves,
-    verbose
+    customHandler
   })
 
   if (!userBlockstore) {

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -19,7 +19,7 @@ export interface PackProperties {
   maxChildrenPerNode?: number,
   wrapWithDirectory?: boolean,
   hasher?: MultihashHasher,
-  customHandler?: (sources: AsyncGenerator<ImportResult, void, unknown>) => AsyncGenerator<any, void, unknown>
+  customStreamSink?: (sources: AsyncGenerator<ImportResult, void, unknown>) => AsyncGenerator<any, void, unknown>
   /**
    * Use raw codec for leaf nodes. Default: true.
    */

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -2,7 +2,7 @@ import last from 'it-last'
 import pipe from 'it-pipe'
 
 import { CarWriter } from '@ipld/car'
-import { importer } from 'ipfs-unixfs-importer'
+import {importer, ImportResult} from 'ipfs-unixfs-importer'
 import { getNormaliser } from './utils/normalise-input'
 import type { ImportCandidateStream, ImportCandidate } from 'ipfs-core-types/src/utils'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
@@ -19,7 +19,7 @@ export interface PackProperties {
   maxChildrenPerNode?: number,
   wrapWithDirectory?: boolean,
   hasher?: MultihashHasher,
-  verbose?: boolean,
+  customHandler?: (sources: AsyncGenerator<ImportResult, void, unknown>) => AsyncGenerator<any, void, unknown>
   /**
    * Use raw codec for leaf nodes. Default: true.
    */

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -8,7 +8,7 @@ import type { ImportCandidateStream, ImportCandidate } from 'ipfs-core-types/src
 import type { MultihashHasher } from 'multiformats/hashes/interface'
 export type { ImportCandidateStream }
 
-import { Blockstore } from '../blockstore/index'
+import { Blockstore } from '../blockstore'
 import { MemoryBlockStore } from '../blockstore/memory'
 import { unixfsImporterOptionsDefault } from './constants'
 
@@ -19,6 +19,7 @@ export interface PackProperties {
   maxChildrenPerNode?: number,
   wrapWithDirectory?: boolean,
   hasher?: MultihashHasher,
+  verbose?: boolean,
   /**
    * Use raw codec for leaf nodes. Default: true.
    */

--- a/src/pack/stream.ts
+++ b/src/pack/stream.ts
@@ -21,7 +21,7 @@ export interface PackToStreamProperties extends PackProperties {
 }
 
 // Node version of toCar with Node Stream Writable
-export async function packToStream ({ input, writable, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, customHandler }: PackToStreamProperties) {
+export async function packToStream ({ input, writable, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, customStreamSink }: PackToStreamProperties) {
   if (!input || (Array.isArray(input) && !input.length)) {
     throw new Error('given input could not be parsed correctly')
   }
@@ -41,7 +41,7 @@ export async function packToStream ({ input, writable, blockstore: userBlockstor
       wrapWithDirectory: wrapWithDirectory === false ? false : unixfsImporterOptionsDefault.wrapWithDirectory,
       rawLeaves: rawLeaves == null ? unixfsImporterOptionsDefault.rawLeaves : rawLeaves
     }),
-    customHandler ? customHandler : (sources: AsyncGenerator<ImportResult, void, unknown>) => sources
+    customStreamSink ? customStreamSink : (sources: AsyncGenerator<ImportResult, void, unknown>) => sources
   ))
 
   if (!rootEntry || !rootEntry.cid) {

--- a/src/pack/stream.ts
+++ b/src/pack/stream.ts
@@ -21,7 +21,7 @@ export interface PackToStreamProperties extends PackProperties {
 }
 
 // Node version of toCar with Node Stream Writable
-export async function packToStream ({ input, writable, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves }: PackToStreamProperties) {
+export async function packToStream ({ input, writable, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, verbose }: PackToStreamProperties) {
   if (!input || (Array.isArray(input) && !input.length)) {
     throw new Error('given input could not be parsed correctly')
   }
@@ -40,7 +40,8 @@ export async function packToStream ({ input, writable, blockstore: userBlockstor
       maxChildrenPerNode: maxChildrenPerNode || unixfsImporterOptionsDefault.maxChildrenPerNode,
       wrapWithDirectory: wrapWithDirectory === false ? false : unixfsImporterOptionsDefault.wrapWithDirectory,
       rawLeaves: rawLeaves == null ? unixfsImporterOptionsDefault.rawLeaves : rawLeaves
-    })
+    }),
+    (source: any) => printCarContent(source, verbose)
   ))
 
   if (!rootEntry || !rootEntry.cid) {

--- a/src/pack/stream.ts
+++ b/src/pack/stream.ts
@@ -21,7 +21,7 @@ export interface PackToStreamProperties extends PackProperties {
 }
 
 // Node version of toCar with Node Stream Writable
-export async function packToStream ({ input, writable, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, verbose }: PackToStreamProperties) {
+export async function packToStream ({ input, writable, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, customHandler }: PackToStreamProperties) {
   if (!input || (Array.isArray(input) && !input.length)) {
     throw new Error('given input could not be parsed correctly')
   }
@@ -41,7 +41,7 @@ export async function packToStream ({ input, writable, blockstore: userBlockstor
       wrapWithDirectory: wrapWithDirectory === false ? false : unixfsImporterOptionsDefault.wrapWithDirectory,
       rawLeaves: rawLeaves == null ? unixfsImporterOptionsDefault.rawLeaves : rawLeaves
     }),
-    (source: any) => printCarContent(source, verbose)
+    customHandler ? customHandler : (sources: AsyncGenerator<ImportResult, void, unknown>) => sources
   ))
 
   if (!rootEntry || !rootEntry.cid) {
@@ -85,15 +85,5 @@ async function * legacyGlobSource (input: Iterable<string> | AsyncIterable<strin
     } else {
       yield { path: fileName, content: fs.createReadStream(resolvedPath) }
     }
-  }
-}
-
-async function *printCarContent(root: AsyncGenerator<ImportResult, void, unknown>, verbose: boolean | undefined): AsyncGenerator<ImportResult, void, unknown> {
-  for await (const entry of root) {
-    if (verbose && entry.path) {
-      // tslint:disable-next-line:no-console
-      console.log(`${entry.cid.toString()} ${entry.path}`)
-    }
-    yield entry
   }
 }

--- a/src/pack/stream.ts
+++ b/src/pack/stream.ts
@@ -6,7 +6,7 @@ import last from 'it-last'
 import pipe from 'it-pipe'
 
 import { CarWriter } from '@ipld/car'
-import { importer } from 'ipfs-unixfs-importer'
+import {importer, ImportResult} from 'ipfs-unixfs-importer'
 import { normaliseInput } from 'ipfs-core-utils/files/normalise-input-multiple'
 import globSource from 'ipfs-utils/src/files/glob-source.js'
 
@@ -84,5 +84,15 @@ async function * legacyGlobSource (input: Iterable<string> | AsyncIterable<strin
     } else {
       yield { path: fileName, content: fs.createReadStream(resolvedPath) }
     }
+  }
+}
+
+async function *printCarContent(root: AsyncGenerator<ImportResult, void, unknown>, verbose: boolean | undefined): AsyncGenerator<ImportResult, void, unknown> {
+  for await (const entry of root) {
+    if (verbose && entry.path) {
+      // tslint:disable-next-line:no-console
+      console.log(`${entry.cid.toString()} ${entry.path}`)
+    }
+    yield entry
   }
 }


### PR DESCRIPTION
In order for people to have a much easier time with associating CIDs with the filename, there is now the option `--list-full` that displays on the same line the CID and the file path.

A verbose option is available with the packing function.
It allows to print which file is being processed during packing.