### PR TITLE
Add support for packing car files with CIDv0

### DIFF
--- a/src/pack/fs.ts
+++ b/src/pack/fs.ts
@@ -12,7 +12,7 @@ export interface PackToFsProperties extends PackProperties {
   output?: string
 }
 
-export async function packToFs ({ input, output, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, rawLeaves, customStreamSink }: PackToFsProperties) {
+export async function packToFs ({ input, output, blockstore: userBlockstore, hasher, maxChunkSize, maxChildrenPerNode, wrapWithDirectory, cidVersion, rawLeaves, customStreamSink }: PackToFsProperties) {
   const blockstore = userBlockstore ? userBlockstore : new FsBlockStore()
   const location = output || `${os.tmpdir()}/${(parseInt(String(Math.random() * 1e9), 10)).toString() + Date.now()}`
   const writable = fs.createWriteStream(location)
@@ -25,6 +25,7 @@ export async function packToFs ({ input, output, blockstore: userBlockstore, has
     maxChunkSize,
     maxChildrenPerNode,
     wrapWithDirectory,
+    cidVersion,
     rawLeaves,
     customStreamSink
   })

--- a/test/pack/index.node.test.ts
+++ b/test/pack/index.node.test.ts
@@ -249,6 +249,17 @@ describe('pack', () => {
         expect(() => root.toV0()).to.not.throw()
         expect(root.toV0().toString()).to.eql('QmNUCKvjKRFeHZR2wyYM5cPEbEB969hz2zowTYvwGrQXP2')
       })
+
+      it('can create a v0 CID', async () => {
+        const { root } = await pack({
+          input: [new Uint8Array([21, 31])],
+          blockstore: new Blockstore(),
+          wrapWithDirectory: false,
+          cidVersion: 0
+        })
+
+        expect(root.toString()).to.eql('QmNUCKvjKRFeHZR2wyYM5cPEbEB969hz2zowTYvwGrQXP2')
+      })
     })
   })
 })


### PR DESCRIPTION
ipfs-car accepts --cidVersion <0|1> flag defaulting to 1, any other value results in an error.

When cidVersion is set to 0, we need to override rawLeaves' value to false, otherwise js-ipfs-unixfs's importer sets the codec to raw instead of dag-pb, which doesn't work with CIDv0