### PR TITLE
feat(cli): check block hash consistency when listing blocks

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -47,6 +47,7 @@ cli
 cli
   .command('blocks [car]')
   .describe('List block CIDs from a CAR.')
+  .option('--verify', 'Verify block hash consistency.', true)
   .action(createAction('./cmd/blocks.js'))
 
 cli

--- a/cmd/blocks.js
+++ b/cmd/blocks.js
@@ -1,10 +1,19 @@
 import fs from 'fs'
-import { CarCIDIterator } from '@ipld/car/iterator'
+import { validateBlock } from '@web3-storage/car-block-validator'
+import { CarBlockIterator } from '@ipld/car/iterator'
 
-/** @param {string} carPath */
-export default async function blocksList (carPath) {
-  const cids = await CarCIDIterator.fromIterable(carPath ? fs.createReadStream(carPath) : process.stdin)
-  for await (const cid of cids) {
-    console.log(cid.toString())
+/**
+ * @param {string} carPath
+ * @param {object} [opts]
+ * @param {boolean} [opts.verify]
+ */
+export default async function blocksList (carPath, opts) {
+  const blocks = await CarBlockIterator.fromIterable(carPath ? fs.createReadStream(carPath) : process.stdin)
+  for await (const block of blocks) {
+    if (opts?.verify || opts?.verify == null) {
+      // @ts-expect-error
+      await validateBlock(block)
+    }
+    console.log(block.cid.toString())
   }
 }

--- a/cmd/blocks.js
+++ b/cmd/blocks.js
@@ -10,6 +10,7 @@ import { CarBlockIterator } from '@ipld/car/iterator'
 export default async function blocksList (carPath, opts) {
   const blocks = await CarBlockIterator.fromIterable(carPath ? fs.createReadStream(carPath) : process.stdin)
   for await (const block of blocks) {
+    /* c8 ignore next */
     if (opts?.verify || opts?.verify == null) {
       // @ts-expect-error
       await validateBlock(block)


### PR DESCRIPTION
Checks the block hash consistency when listing blocks in the CAR. Pass `--no-verify` to disable.

e.g.

```console
$ ipfs-car blocks ciqaih44edpp6equhdeacnifzxpqfoyr425e3hjef2autya5ohuq5ty.car
bafk2bzaceb6ddglkmua3upv2hhapl5dhklkc27xggtmndq6nqmtfkoay54gbs
bafk2bzacedu4gpmt2aqhq5gznjdmz4anxf64l34heez67rllizb6izvuqzava
file:///Users/alan/Code/web3-storage/ipfs-car/node_modules/@web3-storage/car-block-validator/esm/src/index.js:52
    throw new Error('CID hash does not match bytes');
          ^

Error: CID hash does not match bytes
    at validateBlock (file:///Users/alan/Code/web3-storage/ipfs-car/node_modules/@web3-storage/car-block-validator/esm/src/index.js:52:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Module.blocksList (file:///Users/alan/Code/web3-storage/ipfs-car/cmd/blocks.js:16:7)

Node.js v20.6.0
```

```console
$ ipfs-car blocks ciqaih44edpp6equhdeacnifzxpqfoyr425e3hjef2autya5ohuq5ty.car --no-verify
bafk2bzaceb6ddglkmua3upv2hhapl5dhklkc27xggtmndq6nqmtfkoay54gbs
bafk2bzacedu4gpmt2aqhq5gznjdmz4anxf64l34heez67rllizb6izvuqzava
bafk2bzaceda5oo2f5wmcwfmqbqkxzdwzszc2bhqnj4lpygliqna7bmbkmzwh4
bafk2bzacedffd2nthrjt6b5nmbsqge633f4qxcn75jijisgkbu6ibvmxa4cl6
bafk2bzacecwbz6go6hpg57dqvc6e3rj7zdwlnlx73d47oxocxw54wsoznfo54
bafk2bzacec4zqgvyniqp3g6q5vwvn4qceplxvzg3cxtxemkocfstdfnrqvlua
bafykbzacedaqcn32xa35ufzadu7sq2w4e2xmcvzvl4f2frjhabhb3tvdi3psq
```