### PR TITLE
feat: streaming sha256 CAR hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-json": "^10.0.1",
         "@ipld/dag-pb": "^4.0.2",
-        "@ipld/unixfs": "^2.1.1",
+        "@ipld/unixfs": "^3.0.0",
         "@web3-storage/car-block-validator": "^1.0.1",
         "files-from-path": "^1.0.0",
         "ipfs-unixfs-exporter": "^13.0.1",
-        "multiformats": "^11.0.2",
+        "multiformats": "^13.0.1",
         "sade": "^1.8.1",
         "varint": "^6.0.0"
       },
@@ -497,6 +497,15 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@ipld/car/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@ipld/dag-cbor": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz",
@@ -505,6 +514,15 @@
         "cborg": "^1.10.0",
         "multiformats": "^11.0.0"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -523,6 +541,15 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@ipld/dag-json/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@ipld/dag-pb": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.2.tgz",
@@ -535,17 +562,25 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@ipld/unixfs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-2.1.1.tgz",
-      "integrity": "sha512-g3gr/3XvfQs4x2VFjlICae09ul5fbWCKRInN6Vgeot2+GH0h/krr3PqZCIo4dy4Ou2mQOsIddxUvG8UZ4p9SbQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/unixfs/-/unixfs-3.0.0.tgz",
+      "integrity": "sha512-Tj3/BPOlnemcZQ2ETIZAO8hqAs9KNzWyX5J9+JCL9jDwvYwjxeYjqJ3v+9DusNvTBmJhZnGVP6ijUHrsuOLp+g==",
       "dependencies": {
         "@ipld/dag-pb": "^4.0.0",
         "@multiformats/murmur3": "^2.1.3",
         "@perma/map": "^1.0.2",
-        "@web-std/stream": "1.0.1",
         "actor": "^2.3.1",
-        "multiformats": "^11.0.1",
+        "multiformats": "^13.0.1",
         "protobufjs": "^7.1.2",
         "rabin-rs": "^2.1.0"
       }
@@ -606,6 +641,15 @@
         "multiformats": "^11.0.0",
         "murmurhash3js-revisited": "^3.0.0"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -744,14 +788,6 @@
       "version": "18.11.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
       "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw=="
-    },
-    "node_modules/@web-std/stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.1.tgz",
-      "integrity": "sha512-tsz4Y0WNDgFA5jwLSeV7/UV5rfMIlj0cPsSLVfTihjaVW0OJPd5NxJ3le1B3yLyqqzRpeG5OAfJAADLc4VoGTA==",
-      "dependencies": {
-        "web-streams-polyfill": "^3.1.1"
-      }
     },
     "node_modules/@web3-storage/car-block-validator": {
       "version": "1.0.1",
@@ -3188,6 +3224,15 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/interface-blockstore/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/interface-store": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-4.1.0.tgz",
@@ -3248,6 +3293,15 @@
         "progress-events": "^1.0.0",
         "uint8arrays": "^4.0.2"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -4394,13 +4448,9 @@
       "dev": true
     },
     "node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.0.1.tgz",
+      "integrity": "sha512-bt3R5iXe2O8xpp3wkmQhC73b/lC4S2ihU8Dndwcsysqbydqb8N+bpP116qMcClZ17g58iSIwtXUTcg2zT4sniA=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -5920,6 +5970,15 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -6004,14 +6063,6 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "@ipld/dag-cbor": "^9.0.0",
     "@ipld/dag-json": "^10.0.1",
     "@ipld/dag-pb": "^4.0.2",
-    "@ipld/unixfs": "^2.1.1",
+    "@ipld/unixfs": "^3.0.0",
     "@web3-storage/car-block-validator": "^1.0.1",
     "files-from-path": "^1.0.0",
     "ipfs-unixfs-exporter": "^13.0.1",
-    "multiformats": "^11.0.2",
+    "multiformats": "^13.0.1",
     "sade": "^1.8.1",
     "varint": "^6.0.0"
   },


### PR DESCRIPTION
In leu of https://github.com/multiformats/js-multiformats/pull/261 landing, this PR uses the nodejs crypto library to create a streaming sha256 hasher.

Before:

```console
$ ipfs-car hash snow.car 
node:internal/fs/promises:516
    throw new ERR_FS_FILE_TOO_LARGE(size);
          ^

RangeError [ERR_FS_FILE_TOO_LARGE]: File size (11998084756) is greater than 2 GiB
    at readFileHandle (node:internal/fs/promises:516:11)
    at async Module.hash (file:///usr/local/lib/node_modules/ipfs-car/cmd/hash.js:13:13) {
  code: 'ERR_FS_FILE_TOO_LARGE'
}

Node.js v20.11.0
```

After:

```console
$ ipfs-car hash snow.car
bagbaierabdsb7q55nozng74qw267etolakl4jwrszyjb5elw43zercwmowva
```

(Note: `snow.car` is an 11GB CAR)

resolves https://github.com/web3-storage/ipfs-car/issues/158